### PR TITLE
feat: validate struct types during typing

### DIFF
--- a/crates/ast/src/ast.rs
+++ b/crates/ast/src/ast.rs
@@ -31,6 +31,7 @@ pub struct File {
 #[derive(Debug, Clone)]
 pub enum Item {
     EnumDef(EnumDef),
+    StructDef(StructDef),
     TraitDef(TraitDef),
     ImplBlock(ImplBlock),
     Fn(Fn),
@@ -50,6 +51,13 @@ pub struct EnumDef {
     pub name: Uident,
     pub generics: Vec<Uident>,
     pub variants: Vec<(Uident, Vec<Ty>)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StructDef {
+    pub name: Uident,
+    pub generics: Vec<Uident>,
+    pub fields: Vec<(Lident, Ty)>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/ast/src/ast_pprint.rs
+++ b/crates/ast/src/ast_pprint.rs
@@ -1,5 +1,6 @@
 use crate::ast::{
-    Arm, EnumDef, Expr, File, Fn, ImplBlock, Item, Pat, TraitDef, TraitMethodSignature, Ty,
+    Arm, EnumDef, Expr, File, Fn, ImplBlock, Item, Pat, StructDef, TraitDef, TraitMethodSignature,
+    Ty,
 };
 use pretty::RcDoc;
 
@@ -282,6 +283,37 @@ impl EnumDef {
     }
 }
 
+impl StructDef {
+    pub fn to_doc(&self) -> RcDoc<'_, ()> {
+        let header = RcDoc::text("struct")
+            .append(RcDoc::space())
+            .append(RcDoc::text(&self.name.0));
+
+        let fields_doc = RcDoc::concat(self.fields.iter().map(|(name, ty)| {
+            RcDoc::hardline()
+                .append(RcDoc::text(&name.0))
+                .append(RcDoc::text(":"))
+                .append(RcDoc::space())
+                .append(ty.to_doc())
+                .append(RcDoc::text(","))
+        }));
+
+        header
+            .append(RcDoc::space())
+            .append(RcDoc::text("{"))
+            .append(fields_doc.nest(4))
+            .append(RcDoc::hardline())
+            .append(RcDoc::text("}"))
+            .group()
+    }
+
+    pub fn to_pretty(&self, width: usize) -> String {
+        let mut w = Vec::new();
+        self.to_doc().render(width, &mut w).unwrap();
+        String::from_utf8(w).unwrap()
+    }
+}
+
 impl TraitDef {
     pub fn to_doc(&self) -> RcDoc<'_, ()> {
         let header = RcDoc::text("trait")
@@ -422,6 +454,7 @@ impl Item {
     pub fn to_doc(&self) -> RcDoc<'_, ()> {
         match self {
             Item::EnumDef(def) => def.to_doc(),
+            Item::StructDef(def) => def.to_doc(),
             Item::TraitDef(def) => def.to_doc(),
             Item::ImplBlock(def) => def.to_doc(),
             Item::Fn(func) => func.to_doc(),

--- a/crates/compiler/src/env.rs
+++ b/crates/compiler/src/env.rs
@@ -11,6 +11,13 @@ pub struct EnumDef {
     pub variants: Vec<(Uident, Vec<tast::Ty>)>,
 }
 
+#[derive(Debug, Clone)]
+pub struct StructDef {
+    pub name: Uident,
+    pub generics: Vec<Uident>,
+    pub fields: Vec<(Lident, tast::Ty)>,
+}
+
 pub fn encode_trait_impl(trait_name: &Uident, type_name: &tast::Ty) -> String {
     let trait_name = trait_name.0.clone();
     let type_name = type_name.clone();
@@ -64,6 +71,7 @@ pub enum Constraint {
 pub struct Env {
     counter: Cell<i32>,
     pub enums: IndexMap<Uident, EnumDef>,
+    pub structs: IndexMap<Uident, StructDef>,
     pub trait_defs: IndexMap<String, tast::Ty>,
     pub overloaded_funcs_to_trait_name: IndexMap<String, Uident>,
     pub trait_impls: IndexMap<(String, tast::Ty, Lident), tast::Ty>,
@@ -83,6 +91,7 @@ impl Env {
         Self {
             counter: Cell::new(0),
             enums: IndexMap::new(),
+            structs: IndexMap::new(),
             funcs: IndexMap::new(),
             trait_defs: IndexMap::new(),
             overloaded_funcs_to_trait_name: IndexMap::new(),

--- a/crates/compiler/src/rename.rs
+++ b/crates/compiler/src/rename.rs
@@ -53,6 +53,7 @@ impl Rename {
     pub fn rename_item(&self, item: &ast::Item) -> ast::Item {
         match item {
             ast::Item::EnumDef(_) => item.clone(),
+            ast::Item::StructDef(_) => item.clone(),
             ast::Item::TraitDef(_) => item.clone(),
             ast::Item::ImplBlock(i) => ast::Item::ImplBlock(ast::ImplBlock {
                 trait_name: i.trait_name.clone(),

--- a/crates/compiler/src/tests/mod.rs
+++ b/crates/compiler/src/tests/mod.rs
@@ -5,6 +5,7 @@ use cst::cst::CstNode;
 use parser::{debug_tree, syntax::MySyntaxNode};
 
 mod query_test;
+mod struct_type_test;
 
 #[test]
 fn test_cases() -> anyhow::Result<()> {

--- a/crates/compiler/src/tests/struct_type_test.rs
+++ b/crates/compiler/src/tests/struct_type_test.rs
@@ -1,0 +1,118 @@
+use std::path::PathBuf;
+
+use ast::ast::Uident;
+use cst::cst::CstNode;
+use parser::syntax::MySyntaxNode;
+
+use crate::{env::Env, tast};
+
+fn typecheck(src: &str) -> (tast::File, Env) {
+    let path = PathBuf::from("test_structs.gom");
+    let parsed = parser::parse(&path, src);
+    let root = MySyntaxNode::new_root(parsed.green_node);
+    let cst = cst::cst::File::cast(root).expect("failed to cast syntax tree");
+    let ast = ast::lower::lower(cst).expect("failed to lower to AST");
+    crate::typer::check_file(ast)
+}
+
+#[test]
+fn collects_struct_definitions() {
+    let src = r#"
+struct Point {
+    x: Int,
+    y: Int,
+}
+
+struct Wrapper[T] {
+    value: T,
+}
+
+fn consume_point(p: Point) -> Unit { () }
+
+fn consume_wrapper[T](value: Wrapper[T]) -> Unit { () }
+"#;
+
+    let (_tast, env) = typecheck(src);
+
+    let point = env
+        .structs
+        .get(&Uident::new("Point"))
+        .expect("Point struct to be recorded");
+    assert!(point.generics.is_empty());
+    assert_eq!(point.fields.len(), 2);
+    assert_eq!(point.fields[0].0.0, "x");
+    assert_eq!(point.fields[0].1, tast::Ty::TInt);
+    assert_eq!(point.fields[1].0.0, "y");
+    assert_eq!(point.fields[1].1, tast::Ty::TInt);
+
+    let wrapper = env
+        .structs
+        .get(&Uident::new("Wrapper"))
+        .expect("Wrapper struct to be recorded");
+    assert_eq!(wrapper.generics.len(), 1);
+    assert_eq!(wrapper.generics[0].0, "T");
+    assert_eq!(wrapper.fields.len(), 1);
+    assert_eq!(wrapper.fields[0].0.0, "value");
+    assert_eq!(
+        wrapper.fields[0].1,
+        tast::Ty::TParam {
+            name: "T".to_string(),
+        }
+    );
+
+    let wrapper_fn = env
+        .funcs
+        .get("consume_wrapper")
+        .expect("function type to be recorded");
+    if let tast::Ty::TFunc { params, ret_ty } = wrapper_fn {
+        assert_eq!(params.len(), 1);
+        assert_eq!(**ret_ty, tast::Ty::TUnit);
+        let expected_param = tast::Ty::TApp {
+            name: Uident::new("Wrapper"),
+            args: vec![tast::Ty::TParam {
+                name: "T".to_string(),
+            }],
+        };
+        assert_eq!(params[0], expected_param);
+    } else {
+        panic!("expected consume_wrapper to have function type");
+    }
+}
+
+#[test]
+#[should_panic(expected = "Type Wrapper expects 1 type arguments, but got 2")]
+fn struct_type_arity_mismatch_panics() {
+    let src = r#"
+struct Wrapper[T] {
+    value: T,
+}
+
+fn bad(value: Wrapper[Int, Int]) -> Unit { () }
+"#;
+
+    let _ = typecheck(src);
+}
+
+#[test]
+#[should_panic(expected = "Unknown type constructor Undefined")]
+fn unknown_type_constructor_panics() {
+    let src = r#"
+fn bad(p: Undefined) -> Unit { () }
+"#;
+
+    let _ = typecheck(src);
+}
+
+#[test]
+#[should_panic(expected = "Unknown type constructor U")]
+fn unbound_type_parameter_panics() {
+    let src = r#"
+struct Wrapper[T] {
+    value: T,
+}
+
+fn bad[T](value: Wrapper[U]) -> Unit { () }
+"#;
+
+    let _ = typecheck(src);
+}


### PR DESCRIPTION
## Summary
- validate enum and struct type annotations during typing so unknown types and wrong arities are rejected
- register type constructors before validation to support forward references
- add struct type unit tests covering successful collection and common error cases

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68ca9b2ec7d8832bae15605d8e10f35a