### PR TITLE
feat: emit structs in go backend

### DIFF
--- a/crates/compiler/src/tests/cases/019.src
+++ b/crates/compiler/src/tests/cases/019.src
@@ -1,0 +1,25 @@
+struct Point {
+    x: Int,
+    y: Int,
+}
+
+struct Wrapper[T] {
+    value: T,
+}
+
+fn takes_point(p: Point) -> Int {
+    0
+}
+
+fn id_wrapper_int(value: Wrapper[Int]) -> Wrapper[Int] {
+    value
+}
+
+fn takes_wrapper_unit(value: Wrapper[Unit]) -> Unit {
+    ()
+}
+
+fn main() {
+    let _ = string_println("structs!") in
+    ()
+}

--- a/crates/compiler/src/tests/cases/019.src.anf
+++ b/crates/compiler/src/tests/cases/019.src.anf
@@ -1,0 +1,16 @@
+fn takes_point(p/0: Point) -> Int {
+  0
+}
+
+fn id_wrapper_int(value/1: Wrapper__Int) -> Wrapper__Int {
+  value/1
+}
+
+fn takes_wrapper_unit(value/2: Wrapper__Unit) -> Unit {
+  ()
+}
+
+fn main() -> Unit {
+  let mtmp0 = string_println("structs!") in
+  ()
+}

--- a/crates/compiler/src/tests/cases/019.src.ast
+++ b/crates/compiler/src/tests/cases/019.src.ast
@@ -1,0 +1,26 @@
+struct Point {
+    x: Int,
+    y: Int,
+}
+
+struct Wrapper {
+    value: T,
+}
+
+fn takes_point(p: Point) -> Int {
+    0
+}
+
+fn id_wrapper_int(value: Wrapper[Int]) -> Wrapper[Int] {
+    value
+}
+
+fn takes_wrapper_unit(value: Wrapper[Unit]) -> Unit {
+    ()
+}
+
+fn main() {
+    let _ = string_println("structs!") in
+    ()
+}
+

--- a/crates/compiler/src/tests/cases/019.src.core
+++ b/crates/compiler/src/tests/cases/019.src.core
@@ -1,0 +1,16 @@
+fn takes_point(p/0: Point) -> Int {
+  0
+}
+
+fn id_wrapper_int(value/1: Wrapper[Int]) -> Wrapper[Int] {
+  value/1
+}
+
+fn takes_wrapper_unit(value/2: Wrapper[Unit]) -> Unit {
+  ()
+}
+
+fn main() -> Unit {
+  let mtmp0 = string_println("structs!") in
+  ()
+}

--- a/crates/compiler/src/tests/cases/019.src.cst
+++ b/crates/compiler/src/tests/cases/019.src.cst
@@ -1,0 +1,186 @@
+FILE@0..319
+  STRUCT@0..42
+    StructKeyword@0..6 "struct"
+    Whitespace@6..7 " "
+    Uident@7..12 "Point"
+    Whitespace@12..13 " "
+    LBrace@13..14 "{"
+    Whitespace@14..19 "\n    "
+    STRUCT_FIELD_LIST@19..42
+      STRUCT_FIELD@19..25
+        Lident@19..20 "x"
+        Colon@20..21 ":"
+        Whitespace@21..22 " "
+        TYPE_INT@22..25
+          IntKeyword@22..25 "Int"
+      Comma@25..26 ","
+      Whitespace@26..31 "\n    "
+      STRUCT_FIELD@31..37
+        Lident@31..32 "y"
+        Colon@32..33 ":"
+        Whitespace@33..34 " "
+        TYPE_INT@34..37
+          IntKeyword@34..37 "Int"
+      Comma@37..38 ","
+      Whitespace@38..39 "\n"
+      RBrace@39..40 "}"
+      Whitespace@40..42 "\n\n"
+  STRUCT@42..79
+    StructKeyword@42..48 "struct"
+    Whitespace@48..49 " "
+    Uident@49..56 "Wrapper"
+    GENERIC_LIST@56..60
+      LBracket@56..57 "["
+      GENERIC@57..58
+        Uident@57..58 "T"
+      RBracket@58..59 "]"
+      Whitespace@59..60 " "
+    LBrace@60..61 "{"
+    Whitespace@61..66 "\n    "
+    STRUCT_FIELD_LIST@66..79
+      STRUCT_FIELD@66..74
+        Lident@66..71 "value"
+        Colon@71..72 ":"
+        Whitespace@72..73 " "
+        TYPE_TAPP@73..74
+          Uident@73..74 "T"
+      Comma@74..75 ","
+      Whitespace@75..76 "\n"
+      RBrace@76..77 "}"
+      Whitespace@77..79 "\n\n"
+  FN@79..122
+    FnKeyword@79..81 "fn"
+    Whitespace@81..82 " "
+    Lident@82..93 "takes_point"
+    PARAM_LIST@93..104
+      LParen@93..94 "("
+      PARAM@94..102
+        Lident@94..95 "p"
+        Colon@95..96 ":"
+        Whitespace@96..97 " "
+        TYPE_TAPP@97..102
+          Uident@97..102 "Point"
+      RParen@102..103 ")"
+      Whitespace@103..104 " "
+    Arrow@104..106 "->"
+    Whitespace@106..107 " "
+    TYPE_INT@107..111
+      IntKeyword@107..110 "Int"
+      Whitespace@110..111 " "
+    BLOCK@111..122
+      LBrace@111..112 "{"
+      Whitespace@112..117 "\n    "
+      EXPR_INT@117..119
+        Int@117..118 "0"
+        Whitespace@118..119 "\n"
+      RBrace@119..120 "}"
+      Whitespace@120..122 "\n\n"
+  FN@122..192
+    FnKeyword@122..124 "fn"
+    Whitespace@124..125 " "
+    Lident@125..139 "id_wrapper_int"
+    PARAM_LIST@139..161
+      LParen@139..140 "("
+      PARAM@140..159
+        Lident@140..145 "value"
+        Colon@145..146 ":"
+        Whitespace@146..147 " "
+        TYPE_TAPP@147..159
+          Uident@147..154 "Wrapper"
+          TYPE_PARAM_LIST@154..159
+            LBracket@154..155 "["
+            TYPE_INT@155..158
+              IntKeyword@155..158 "Int"
+            RBracket@158..159 "]"
+      RParen@159..160 ")"
+      Whitespace@160..161 " "
+    Arrow@161..163 "->"
+    Whitespace@163..164 " "
+    TYPE_TAPP@164..177
+      Uident@164..171 "Wrapper"
+      TYPE_PARAM_LIST@171..177
+        LBracket@171..172 "["
+        TYPE_INT@172..175
+          IntKeyword@172..175 "Int"
+        RBracket@175..176 "]"
+        Whitespace@176..177 " "
+    BLOCK@177..192
+      LBrace@177..178 "{"
+      Whitespace@178..183 "\n    "
+      EXPR_LIDENT@183..189
+        Lident@183..188 "value"
+        Whitespace@188..189 "\n"
+      RBrace@189..190 "}"
+      Whitespace@190..192 "\n\n"
+  FN@192..256
+    FnKeyword@192..194 "fn"
+    Whitespace@194..195 " "
+    Lident@195..213 "takes_wrapper_unit"
+    PARAM_LIST@213..236
+      LParen@213..214 "("
+      PARAM@214..234
+        Lident@214..219 "value"
+        Colon@219..220 ":"
+        Whitespace@220..221 " "
+        TYPE_TAPP@221..234
+          Uident@221..228 "Wrapper"
+          TYPE_PARAM_LIST@228..234
+            LBracket@228..229 "["
+            TYPE_UNIT@229..233
+              UnitKeyword@229..233 "Unit"
+            RBracket@233..234 "]"
+      RParen@234..235 ")"
+      Whitespace@235..236 " "
+    Arrow@236..238 "->"
+    Whitespace@238..239 " "
+    TYPE_UNIT@239..244
+      UnitKeyword@239..243 "Unit"
+      Whitespace@243..244 " "
+    BLOCK@244..256
+      LBrace@244..245 "{"
+      Whitespace@245..250 "\n    "
+      EXPR_UNIT@250..253
+        LParen@250..251 "("
+        RParen@251..252 ")"
+        Whitespace@252..253 "\n"
+      RBrace@253..254 "}"
+      Whitespace@254..256 "\n\n"
+  FN@256..319
+    FnKeyword@256..258 "fn"
+    Whitespace@258..259 " "
+    Lident@259..263 "main"
+    PARAM_LIST@263..266
+      LParen@263..264 "("
+      RParen@264..265 ")"
+      Whitespace@265..266 " "
+    BLOCK@266..319
+      LBrace@266..267 "{"
+      Whitespace@267..272 "\n    "
+      EXPR_LET@272..317
+        LetKeyword@272..275 "let"
+        Whitespace@275..276 " "
+        PATTERN_WILDCARD@276..278
+          WildcardKeyword@276..277 "_"
+          Whitespace@277..278 " "
+        Eq@278..279 "="
+        Whitespace@279..280 " "
+        EXPR_LET_VALUE@280..307
+          EXPR_CALL@280..307
+            EXPR_LIDENT@280..294
+              Lident@280..294 "string_println"
+            ARG_LIST@294..307
+              LParen@294..295 "("
+              ARG@295..305
+                EXPR_STR@295..305
+                  Str@295..305 "\"structs!\""
+              RParen@305..306 ")"
+              Whitespace@306..307 " "
+        InKeyword@307..309 "in"
+        Whitespace@309..314 "\n    "
+        EXPR_LET_BODY@314..317
+          EXPR_UNIT@314..317
+            LParen@314..315 "("
+            RParen@315..316 ")"
+            Whitespace@316..317 "\n"
+      RBrace@317..318 "}"
+      Whitespace@318..319 "\n"

--- a/crates/compiler/src/tests/cases/019.src.gom
+++ b/crates/compiler/src/tests/cases/019.src.gom
@@ -1,0 +1,90 @@
+package main
+
+import (
+    "fmt"
+)
+
+func unit_to_string(x struct{}) string {
+    return "()"
+}
+
+func bool_to_string(x bool) string {
+    if x {
+        return "true"
+    } else {
+        return "false"
+    }
+}
+
+func int_to_string(x int) string {
+    return fmt.Sprintf("%d", x)
+}
+
+func int_add(x int, y int) int {
+    return x + y
+}
+
+func int_sub(x int, y int) int {
+    return x - y
+}
+
+func int_less(x int, y int) bool {
+    return x < y
+}
+
+func string_print(s string) struct{} {
+    fmt.Print(s)
+    return struct{}{}
+}
+
+func string_println(s string) struct{} {
+    fmt.Println(s)
+    return struct{}{}
+}
+
+func missing(s string) struct{} {
+    panic("missing: " + s)
+    return struct{}{}
+}
+
+type Point struct {
+    x int
+    y int
+}
+
+type Wrapper__Int struct {
+    value int
+}
+
+type Wrapper__Unit struct {
+    value struct{}
+}
+
+func takes_point(p__0 Point) int {
+    var ret1 int
+    ret1 = 0
+    return ret1
+}
+
+func id_wrapper_int(value__1 Wrapper__Int) Wrapper__Int {
+    var ret2 Wrapper__Int
+    ret2 = value__1
+    return ret2
+}
+
+func takes_wrapper_unit(value__2 Wrapper__Unit) struct{} {
+    var ret3 struct{}
+    ret3 = struct{}{}
+    return ret3
+}
+
+func main0() struct{} {
+    var ret4 struct{}
+    string_println("structs!")
+    ret4 = struct{}{}
+    return ret4
+}
+
+func main() {
+    main0()
+}

--- a/crates/compiler/src/tests/cases/019.src.mono
+++ b/crates/compiler/src/tests/cases/019.src.mono
@@ -1,0 +1,16 @@
+fn takes_point(p/0: Point) -> Int {
+  0
+}
+
+fn id_wrapper_int(value/1: Wrapper__Int) -> Wrapper__Int {
+  value/1
+}
+
+fn takes_wrapper_unit(value/2: Wrapper__Unit) -> Unit {
+  ()
+}
+
+fn main() -> Unit {
+  let mtmp0 = string_println("structs!") in
+  ()
+}

--- a/crates/compiler/src/tests/cases/019.src.out
+++ b/crates/compiler/src/tests/cases/019.src.out
@@ -1,0 +1,1 @@
+structs!

--- a/crates/compiler/src/tests/cases/019.src.tast
+++ b/crates/compiler/src/tests/cases/019.src.tast
@@ -1,0 +1,16 @@
+fn takes_point(p/0: Point) -> Int {
+  0
+}
+
+fn id_wrapper_int(value/1: Wrapper[Int]) -> Wrapper[Int] {
+  (value/1 : Wrapper[Int])
+}
+
+fn takes_wrapper_unit(value/2: Wrapper[Unit]) -> Unit {
+  ()
+}
+
+fn main() -> Unit {
+  let _ : Unit = string_println("structs!") in
+  ()
+}


### PR DESCRIPTION
## Summary
- monomorphize struct type applications alongside enums so the Go backend works with concrete struct names
- emit Go struct declarations for monomorphic struct types
- add an end-to-end regression case covering struct types (019)

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68caa3f5f77c832b93d742af8760bfb7