### PR TITLE
refactor: lowercase builtin types

### DIFF
--- a/crates/ast/src/ast_pprint.rs
+++ b/crates/ast/src/ast_pprint.rs
@@ -7,10 +7,10 @@ use pretty::RcDoc;
 impl Ty {
     pub fn to_doc(&self) -> RcDoc<'_, ()> {
         match self {
-            Self::TUnit => RcDoc::text("Unit"),
-            Self::TBool => RcDoc::text("Bool"),
-            Self::TInt => RcDoc::text("Int"),
-            Self::TString => RcDoc::text("String"),
+            Self::TUnit => RcDoc::text("unit"),
+            Self::TBool => RcDoc::text("bool"),
+            Self::TInt => RcDoc::text("int"),
+            Self::TString => RcDoc::text("string"),
             Self::TTuple { typs } => {
                 let mut doc = RcDoc::text("(");
 

--- a/crates/compiler/src/env.rs
+++ b/crates/compiler/src/env.rs
@@ -24,16 +24,16 @@ pub struct StructDef {
 pub fn encode_trait_impl(trait_name: &Uident, type_name: &tast::Ty) -> String {
     let trait_name = trait_name.0.clone();
     let type_name = type_name.clone();
-    // impl ToString for Int
-    // __ToString%Int
+    // impl ToString for int
+    // __ToString%int
     format!(
         "__{}%{}",
         trait_name,
         match type_name {
-            tast::Ty::TUnit => "Unit".to_string(),
-            tast::Ty::TInt => "Int".to_string(),
-            tast::Ty::TBool => "Bool".to_string(),
-            tast::Ty::TString => "String".to_string(),
+            tast::Ty::TUnit => "unit".to_string(),
+            tast::Ty::TInt => "int".to_string(),
+            tast::Ty::TBool => "bool".to_string(),
+            tast::Ty::TString => "string".to_string(),
             _ => {
                 todo!()
             }
@@ -48,10 +48,10 @@ pub fn decode_trait_impl(impl_name: &str) -> (Uident, tast::Ty) {
     }
     let trait_name = Uident::new(parts[0].trim_start_matches("__"));
     let type_name = match parts[1] {
-        "Unit" => tast::Ty::TUnit,
-        "Bool" => tast::Ty::TBool,
-        "Int" => tast::Ty::TInt,
-        "String" => tast::Ty::TString,
+        "unit" => tast::Ty::TUnit,
+        "bool" => tast::Ty::TBool,
+        "int" => tast::Ty::TInt,
+        "string" => tast::Ty::TString,
         _ => {
             todo!()
         }

--- a/crates/compiler/src/go/goast.rs
+++ b/crates/compiler/src/go/goast.rs
@@ -220,7 +220,7 @@ pub fn tast_ty_to_go_type(ty: &tast::Ty) -> goty::GoType {
 
 pub fn go_type_name_for(ty: &tast::Ty) -> String {
     match ty {
-        tast::Ty::TUnit => "Unit".to_string(),
+        tast::Ty::TUnit => "unit".to_string(),
         tast::Ty::TBool => "bool".to_string(),
         tast::Ty::TInt => "int".to_string(),
         tast::Ty::TString => "string".to_string(),

--- a/crates/compiler/src/mangle.rs
+++ b/crates/compiler/src/mangle.rs
@@ -4,10 +4,10 @@ use ::ast::ast;
 pub fn mangle_impl_name(trait_name: &ast::Uident, for_ty: &tast::Ty, method_name: &str) -> String {
     // Create a unique string representation of the type `for_ty`. Handle complex types carefully.
     let for_ty_str = match for_ty {
-        tast::Ty::TUnit => "Unit".to_string(),
-        tast::Ty::TBool => "Bool".to_string(),
-        tast::Ty::TInt => "Int".to_string(),
-        tast::Ty::TString => "String".to_string(),
+        tast::Ty::TUnit => "unit".to_string(),
+        tast::Ty::TBool => "bool".to_string(),
+        tast::Ty::TInt => "int".to_string(),
+        tast::Ty::TString => "string".to_string(),
         tast::Ty::TTuple { typs } => {
             let inner = typs
                 .iter()

--- a/crates/compiler/src/mono.rs
+++ b/crates/compiler/src/mono.rs
@@ -72,10 +72,10 @@ pub fn mono(env: &mut Env, file: core::File) -> core::File {
 
     fn encode_ty(ty: &Ty) -> String {
         match ty {
-            Ty::TUnit => "Unit".to_string(),
-            Ty::TBool => "Bool".to_string(),
-            Ty::TInt => "Int".to_string(),
-            Ty::TString => "String".to_string(),
+            Ty::TUnit => "unit".to_string(),
+            Ty::TBool => "bool".to_string(),
+            Ty::TInt => "int".to_string(),
+            Ty::TString => "string".to_string(),
             Ty::TVar(_v) => "Var".to_string(),
             Ty::TParam { name } => format!("TParam_{}", name),
             Ty::TTuple { typs } => {

--- a/crates/compiler/src/pprint/tast_pprint.rs
+++ b/crates/compiler/src/pprint/tast_pprint.rs
@@ -114,10 +114,10 @@ impl Ty {
     pub fn to_doc(&self, _env: &Env) -> RcDoc<'_, ()> {
         match self {
             Self::TVar(x) => RcDoc::text(format!("{:?}", x)),
-            Self::TUnit => RcDoc::text("Unit"),
-            Self::TBool => RcDoc::text("Bool"),
-            Self::TInt => RcDoc::text("Int"),
-            Self::TString => RcDoc::text("String"),
+            Self::TUnit => RcDoc::text("unit"),
+            Self::TBool => RcDoc::text("bool"),
+            Self::TInt => RcDoc::text("int"),
+            Self::TString => RcDoc::text("string"),
             Self::TTuple { typs } => {
                 let mut doc = RcDoc::text("(");
 

--- a/crates/compiler/src/tests/cases/001.src.anf
+++ b/crates/compiler/src/tests/cases/001.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = () in
   let t7 = (true, false) in
   let a/0 = (true, false, t7) in

--- a/crates/compiler/src/tests/cases/001.src.core
+++ b/crates/compiler/src/tests/cases/001.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = () in
   let a/0 = (true, false, (true, false)) in
   let b/5 = let x1 = a/0.0 in

--- a/crates/compiler/src/tests/cases/001.src.mono
+++ b/crates/compiler/src/tests/cases/001.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = () in
   let a/0 = (true, false, (true, false)) in
   let b/5 = let x1 = a/0.0 in

--- a/crates/compiler/src/tests/cases/001.src.tast
+++ b/crates/compiler/src/tests/cases/001.src.tast
@@ -1,9 +1,9 @@
-fn main() -> Unit {
-  let _ : Unit = () in
-  let a/0: (Bool, Bool, (Bool, Bool)) = (true, false, (true, false)) in
-  let b/5: Bool = match (a/0 : (Bool, Bool, (Bool, Bool))) {
-      (x/1: Bool, y/2: Bool, (z/3: Bool, w/4: Bool)) => (w/4 : Bool),
+fn main() -> unit {
+  let _ : unit = () in
+  let a/0: (bool, bool, (bool, bool)) = (true, false, (true, false)) in
+  let b/5: bool = match (a/0 : (bool, bool, (bool, bool))) {
+      (x/1: bool, y/2: bool, (z/3: bool, w/4: bool)) => (w/4 : bool),
   } in
-  let _ : Unit = string_print(bool_to_string((b/5 : Bool))) in
+  let _ : unit = string_print(bool_to_string((b/5 : bool))) in
   ()
 }

--- a/crates/compiler/src/tests/cases/002.src.anf
+++ b/crates/compiler/src/tests/cases/002.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, false) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/002.src.core
+++ b/crates/compiler/src/tests/cases/002.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, false) in
   let b/1 = let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/002.src.mono
+++ b/crates/compiler/src/tests/cases/002.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, false) in
   let b/1 = let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/002.src.tast
+++ b/crates/compiler/src/tests/cases/002.src.tast
@@ -1,19 +1,19 @@
-fn main() -> Unit {
-  let a/0: (Bool, Bool) = (true, false) in
-  let b/1: (Bool, Bool) = match (a/0 : (Bool, Bool)) {
+fn main() -> unit {
+  let a/0: (bool, bool) = (true, false) in
+  let b/1: (bool, bool) = match (a/0 : (bool, bool)) {
       (false, false) => (true, true),
       (false, true) => (true, false),
       (true, false) => (false, true),
       (true, true) => (false, false),
   } in
-  let b_1/3: Bool = match (b/1 : (Bool, Bool)) {
-      (_ : Bool, w/2: Bool) => (w/2 : Bool),
+  let b_1/3: bool = match (b/1 : (bool, bool)) {
+      (_ : bool, w/2: bool) => (w/2 : bool),
   } in
-  let c/4: Unit = match (true, (b_1/3 : Bool)) {
+  let c/4: unit = match (true, (b_1/3 : bool)) {
       (false, false) => string_print(int_to_string(0)),
       (false, true) => string_print(int_to_string(1)),
       (true, false) => string_print(int_to_string(2)),
       (true, true) => string_print(int_to_string(3)),
   } in
-  string_print(unit_to_string((c/4 : Unit)))
+  string_print(unit_to_string((c/4 : unit)))
 }

--- a/crates/compiler/src/tests/cases/003.src.anf
+++ b/crates/compiler/src/tests/cases/003.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let t4 = unit_to_string(()) in
   let mtmp0 = string_print(t4) in
   let t5 = bool_to_string(true) in

--- a/crates/compiler/src/tests/cases/003.src.core
+++ b/crates/compiler/src/tests/cases/003.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_print(unit_to_string(())) in
   let mtmp1 = string_print(bool_to_string(true)) in
   let mtmp2 = string_print(bool_to_string(false)) in

--- a/crates/compiler/src/tests/cases/003.src.mono
+++ b/crates/compiler/src/tests/cases/003.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_print(unit_to_string(())) in
   let mtmp1 = string_print(bool_to_string(true)) in
   let mtmp2 = string_print(bool_to_string(false)) in

--- a/crates/compiler/src/tests/cases/003.src.tast
+++ b/crates/compiler/src/tests/cases/003.src.tast
@@ -1,7 +1,7 @@
-fn main() -> Unit {
-  let _ : Unit = string_print(unit_to_string(())) in
-  let _ : Unit = string_print(bool_to_string(true)) in
-  let _ : Unit = string_print(bool_to_string(false)) in
-  let _ : Unit = string_print(int_to_string(123)) in
+fn main() -> unit {
+  let _ : unit = string_print(unit_to_string(())) in
+  let _ : unit = string_print(bool_to_string(true)) in
+  let _ : unit = string_print(bool_to_string(false)) in
+  let _ : unit = string_print(int_to_string(123)) in
   ()
 }

--- a/crates/compiler/src/tests/cases/004.src
+++ b/crates/compiler/src/tests/cases/004.src
@@ -4,7 +4,7 @@ enum Color {
     Blue,
 }
 
-fn main() -> Bool {
+fn main() -> bool {
     let a = (Blue, Blue) in
     match a {
         (Red, Green) => true,

--- a/crates/compiler/src/tests/cases/004.src.anf
+++ b/crates/compiler/src/tests/cases/004.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Bool {
+fn main() -> bool {
   let t3 = Tag_2 in
   let t4 = Tag_2 in
   let a/0 = (t3, t4) in

--- a/crates/compiler/src/tests/cases/004.src.ast
+++ b/crates/compiler/src/tests/cases/004.src.ast
@@ -4,7 +4,7 @@ enum Color {
     Blue
 }
 
-fn main() -> Bool {
+fn main() -> bool {
     let a = (Blue, Blue) in
     match a {
         (Red, Green) => true,

--- a/crates/compiler/src/tests/cases/004.src.core
+++ b/crates/compiler/src/tests/cases/004.src.core
@@ -1,4 +1,4 @@
-fn main() -> Bool {
+fn main() -> bool {
   let a/0 = (Color::Blue, Color::Blue) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/004.src.cst
+++ b/crates/compiler/src/tests/cases/004.src.cst
@@ -32,7 +32,7 @@ FILE@0..271
     Arrow@56..58 "->"
     Whitespace@58..59 " "
     TYPE_BOOL@59..64
-      BoolKeyword@59..63 "Bool"
+      BoolKeyword@59..63 "bool"
       Whitespace@63..64 " "
     BLOCK@64..271
       LBrace@64..65 "{"

--- a/crates/compiler/src/tests/cases/004.src.mono
+++ b/crates/compiler/src/tests/cases/004.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Bool {
+fn main() -> bool {
   let a/0 = (Color::Blue, Color::Blue) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/004.src.tast
+++ b/crates/compiler/src/tests/cases/004.src.tast
@@ -1,9 +1,9 @@
-fn main() -> Bool {
+fn main() -> bool {
   let a/0: (Color, Color) = (Color::Blue, Color::Blue) in
   match (a/0 : (Color, Color)) {
       (Color::Red, Color::Green) => true,
       (Color::Red, Color::Red) => true,
-      (Color::Blue, Color::Blue) => let _ : Unit = string_print(bool_to_string(true)) in
+      (Color::Blue, Color::Blue) => let _ : unit = string_print(bool_to_string(true)) in
         false,
       _ : (Color, Color) => false,
   }

--- a/crates/compiler/src/tests/cases/005.src.anf
+++ b/crates/compiler/src/tests/cases/005.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let t2 = Tag_2 in
   let t3 = Tag_0 in
   let a/0 = (t2, t3) in

--- a/crates/compiler/src/tests/cases/005.src.core
+++ b/crates/compiler/src/tests/cases/005.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (Color::Blue, Color::Red) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/005.src.mono
+++ b/crates/compiler/src/tests/cases/005.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (Color::Blue, Color::Red) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/005.src.tast
+++ b/crates/compiler/src/tests/cases/005.src.tast
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0: (Color, Color) = (Color::Blue, Color::Red) in
   match (a/0 : (Color, Color)) {
       (Color::Red, Color::Green) => string_print(int_to_string(0)),

--- a/crates/compiler/src/tests/cases/006.src.anf
+++ b/crates/compiler/src/tests/cases/006.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, false) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/006.src.core
+++ b/crates/compiler/src/tests/cases/006.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, false) in
   let mtmp2 = let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/006.src.mono
+++ b/crates/compiler/src/tests/cases/006.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, false) in
   let mtmp2 = let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/006.src.tast
+++ b/crates/compiler/src/tests/cases/006.src.tast
@@ -1,12 +1,12 @@
-fn main() -> Unit {
-  let a/0: (Bool, Bool) = (true, false) in
-  let _ : Unit = match (a/0 : (Bool, Bool)) {
-      (true, b/1: Bool) => string_print(bool_to_string((b/1 : Bool))),
-      _ : (Bool, Bool) => (),
+fn main() -> unit {
+  let a/0: (bool, bool) = (true, false) in
+  let _ : unit = match (a/0 : (bool, bool)) {
+      (true, b/1: bool) => string_print(bool_to_string((b/1 : bool))),
+      _ : (bool, bool) => (),
   } in
-  let c/2: (Bool, Bool) = (true, true) in
-  match (c/2 : (Bool, Bool)) {
-      (true, d/3: Bool) => string_print(bool_to_string((d/3 : Bool))),
-      _ : (Bool, Bool) => (),
+  let c/2: (bool, bool) = (true, true) in
+  match (c/2 : (bool, bool)) {
+      (true, d/3: bool) => string_print(bool_to_string((d/3 : bool))),
+      _ : (bool, bool) => (),
   }
 }

--- a/crates/compiler/src/tests/cases/007.src.anf
+++ b/crates/compiler/src/tests/cases/007.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let t51 = Tag_0 in
   let t52 = Tag_0 in
   let t50 = Expr::Add(t51, t52) in

--- a/crates/compiler/src/tests/cases/007.src.core
+++ b/crates/compiler/src/tests/cases/007.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = Expr::Mul(Expr::Add(Expr::Zero, Expr::Zero), Expr::Zero) in
   match a/0 {
     Expr::Zero => {

--- a/crates/compiler/src/tests/cases/007.src.mono
+++ b/crates/compiler/src/tests/cases/007.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = Expr::Mul(Expr::Add(Expr::Zero, Expr::Zero), Expr::Zero) in
   match a/0 {
     Expr::Zero => {

--- a/crates/compiler/src/tests/cases/007.src.tast
+++ b/crates/compiler/src/tests/cases/007.src.tast
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0: Expr = Expr::Mul(Expr::Add(Expr::Zero, Expr::Zero), Expr::Zero) in
   match (a/0 : Expr) {
       Expr::Add(Expr::Zero, Expr::Zero) => string_print(int_to_string(0)),

--- a/crates/compiler/src/tests/cases/008.src
+++ b/crates/compiler/src/tests/cases/008.src
@@ -1,6 +1,6 @@
 enum T {
     A,
-    B(Bool, Unit),
+    B(bool, unit),
 }
 
 fn main() {

--- a/crates/compiler/src/tests/cases/008.src.anf
+++ b/crates/compiler/src/tests/cases/008.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let t/0 = T::B(true, ()) in
   match t/0 {
     Tag_0 => {

--- a/crates/compiler/src/tests/cases/008.src.ast
+++ b/crates/compiler/src/tests/cases/008.src.ast
@@ -1,6 +1,6 @@
 enum T {
     A,
-    B(Bool, Unit)
+    B(bool, unit)
 }
 
 fn main() {

--- a/crates/compiler/src/tests/cases/008.src.core
+++ b/crates/compiler/src/tests/cases/008.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let t/0 = T::B(true, ()) in
   match t/0 {
     T::A => {

--- a/crates/compiler/src/tests/cases/008.src.cst
+++ b/crates/compiler/src/tests/cases/008.src.cst
@@ -16,11 +16,11 @@ FILE@0..255
         TYPE_LIST@21..33
           LParen@21..22 "("
           TYPE_BOOL@22..26
-            BoolKeyword@22..26 "Bool"
+            BoolKeyword@22..26 "bool"
           Comma@26..27 ","
           Whitespace@27..28 " "
           TYPE_UNIT@28..32
-            UnitKeyword@28..32 "Unit"
+            UnitKeyword@28..32 "unit"
           RParen@32..33 ")"
       Comma@33..34 ","
       Whitespace@34..35 "\n"

--- a/crates/compiler/src/tests/cases/008.src.mono
+++ b/crates/compiler/src/tests/cases/008.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let t/0 = T::B(true, ()) in
   match t/0 {
     T::A => {

--- a/crates/compiler/src/tests/cases/008.src.tast
+++ b/crates/compiler/src/tests/cases/008.src.tast
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let t/0: T = T::B(true, ()) in
   match (t/0 : T) {
       T::A => string_print(int_to_string(1)),

--- a/crates/compiler/src/tests/cases/009.src
+++ b/crates/compiler/src/tests/cases/009.src
@@ -1,9 +1,9 @@
 enum T {
     A,
-    B(Bool, Bool),
+    B(bool, bool),
 }
 
-fn test(t: T) -> Unit {
+fn test(t: T) -> unit {
     match t {
         A => string_print(int_to_string(1)),
         B(false, false) => string_print(int_to_string(2)),

--- a/crates/compiler/src/tests/cases/009.src.anf
+++ b/crates/compiler/src/tests/cases/009.src.anf
@@ -1,4 +1,4 @@
-fn test(t/0: T) -> Unit {
+fn test(t/0: T) -> unit {
   match t/0 {
     Tag_0 => {
       let t6 = int_to_string(1) in
@@ -37,7 +37,7 @@ fn test(t/0: T) -> Unit {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t11 = T::B(true, true) in
   let mtmp2 = test(t11) in
   let t12 = T::B(false, true) in

--- a/crates/compiler/src/tests/cases/009.src.ast
+++ b/crates/compiler/src/tests/cases/009.src.ast
@@ -1,9 +1,9 @@
 enum T {
     A,
-    B(Bool, Bool)
+    B(bool, bool)
 }
 
-fn test(t: T) -> Unit {
+fn test(t: T) -> unit {
     match t {
         A => string_print(int_to_string(1)),
         B(false, false) => string_print(int_to_string(2)),

--- a/crates/compiler/src/tests/cases/009.src.core
+++ b/crates/compiler/src/tests/cases/009.src.core
@@ -1,4 +1,4 @@
-fn test(t/0: T) -> Unit {
+fn test(t/0: T) -> unit {
   match t/0 {
     T::A => {
       string_print(int_to_string(1))
@@ -32,7 +32,7 @@ fn test(t/0: T) -> Unit {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp2 = test(T::B(true, true)) in
   let mtmp3 = test(T::B(false, true)) in
   let mtmp4 = test(T::B(false, false)) in

--- a/crates/compiler/src/tests/cases/009.src.cst
+++ b/crates/compiler/src/tests/cases/009.src.cst
@@ -16,11 +16,11 @@ FILE@0..444
         TYPE_LIST@21..33
           LParen@21..22 "("
           TYPE_BOOL@22..26
-            BoolKeyword@22..26 "Bool"
+            BoolKeyword@22..26 "bool"
           Comma@26..27 ","
           Whitespace@27..28 " "
           TYPE_BOOL@28..32
-            BoolKeyword@28..32 "Bool"
+            BoolKeyword@28..32 "bool"
           RParen@32..33 ")"
       Comma@33..34 ","
       Whitespace@34..35 "\n"
@@ -43,7 +43,7 @@ FILE@0..444
     Arrow@52..54 "->"
     Whitespace@54..55 " "
     TYPE_UNIT@55..60
-      UnitKeyword@55..59 "Unit"
+      UnitKeyword@55..59 "unit"
       Whitespace@59..60 " "
     BLOCK@60..292
       LBrace@60..61 "{"

--- a/crates/compiler/src/tests/cases/009.src.mono
+++ b/crates/compiler/src/tests/cases/009.src.mono
@@ -1,4 +1,4 @@
-fn test(t/0: T) -> Unit {
+fn test(t/0: T) -> unit {
   match t/0 {
     T::A => {
       string_print(int_to_string(1))
@@ -32,7 +32,7 @@ fn test(t/0: T) -> Unit {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp2 = test(T::B(true, true)) in
   let mtmp3 = test(T::B(false, true)) in
   let mtmp4 = test(T::B(false, false)) in

--- a/crates/compiler/src/tests/cases/009.src.tast
+++ b/crates/compiler/src/tests/cases/009.src.tast
@@ -1,4 +1,4 @@
-fn test(t/0: T) -> Unit {
+fn test(t/0: T) -> unit {
   match (t/0 : T) {
       T::A => string_print(int_to_string(1)),
       T::B(false, false) => string_print(int_to_string(2)),
@@ -7,10 +7,10 @@ fn test(t/0: T) -> Unit {
   }
 }
 
-fn main() -> Unit {
-  let _ : Unit = test(T::B(true, true)) in
-  let _ : Unit = test(T::B(false, true)) in
-  let _ : Unit = test(T::B(false, false)) in
-  let _ : Unit = test(T::A) in
+fn main() -> unit {
+  let _ : unit = test(T::B(true, true)) in
+  let _ : unit = test(T::B(false, true)) in
+  let _ : unit = test(T::B(false, false)) in
+  let _ : unit = test(T::A) in
   ()
 }

--- a/crates/compiler/src/tests/cases/010.src.anf
+++ b/crates/compiler/src/tests/cases/010.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, true) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/010.src.core
+++ b/crates/compiler/src/tests/cases/010.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, true) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/010.src.mono
+++ b/crates/compiler/src/tests/cases/010.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = (true, true) in
   let x0 = a/0.0 in
   let x1 = a/0.1 in

--- a/crates/compiler/src/tests/cases/010.src.tast
+++ b/crates/compiler/src/tests/cases/010.src.tast
@@ -1,8 +1,8 @@
-fn main() -> Unit {
-  let a/0: (Bool, Bool) = (true, true) in
-  match (a/0 : (Bool, Bool)) {
+fn main() -> unit {
+  let a/0: (bool, bool) = (true, true) in
+  match (a/0 : (bool, bool)) {
       (true, false) => string_print(int_to_string(123)),
       (false, true) => string_print(int_to_string(456)),
-      _ : (Bool, Bool) => string_print(int_to_string(789)),
+      _ : (bool, bool) => string_print(int_to_string(789)),
   }
 }

--- a/crates/compiler/src/tests/cases/011.src.anf
+++ b/crates/compiler/src/tests/cases/011.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = 1 in
   let a/1 = int_add(a/0, 2) in
   let a/2 = int_add(a/1, 3) in

--- a/crates/compiler/src/tests/cases/011.src.core
+++ b/crates/compiler/src/tests/cases/011.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = 1 in
   let a/1 = int_add(a/0, 2) in
   let a/2 = int_add(a/1, 3) in

--- a/crates/compiler/src/tests/cases/011.src.mono
+++ b/crates/compiler/src/tests/cases/011.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = 1 in
   let a/1 = int_add(a/0, 2) in
   let a/2 = int_add(a/1, 3) in

--- a/crates/compiler/src/tests/cases/011.src.tast
+++ b/crates/compiler/src/tests/cases/011.src.tast
@@ -1,7 +1,7 @@
-fn main() -> Unit {
-  let a/0: Int = 1 in
-  let a/1: Int = int_add((a/0 : Int), 2) in
-  let a/2: Int = int_add((a/1 : Int), 3) in
-  let a/3: Int = int_add((a/2 : Int), 4) in
-  string_print(int_to_string((a/3 : Int)))
+fn main() -> unit {
+  let a/0: int = 1 in
+  let a/1: int = int_add((a/0 : int), 2) in
+  let a/2: int = int_add((a/1 : int), 3) in
+  let a/3: int = int_add((a/2 : int), 4) in
+  string_print(int_to_string((a/3 : int)))
 }

--- a/crates/compiler/src/tests/cases/012.src
+++ b/crates/compiler/src/tests/cases/012.src
@@ -1,4 +1,4 @@
-fn fib(x: Int) -> Int {
+fn fib(x: int) -> int {
   match int_less(x, 2) {
     false => int_add(fib(int_sub(x, 1)), fib(int_sub(x, 2))),
     true => 1,

--- a/crates/compiler/src/tests/cases/012.src.anf
+++ b/crates/compiler/src/tests/cases/012.src.anf
@@ -1,4 +1,4 @@
-fn fib(x/0: Int) -> Int {
+fn fib(x/0: int) -> int {
   let mtmp0 = int_less(x/0, 2) in
   match mtmp0 {
     true => {
@@ -14,7 +14,7 @@ fn fib(x/0: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t6 = fib(10) in
   let t5 = int_to_string(t6) in
   string_print(t5)

--- a/crates/compiler/src/tests/cases/012.src.ast
+++ b/crates/compiler/src/tests/cases/012.src.ast
@@ -1,4 +1,4 @@
-fn fib(x: Int) -> Int {
+fn fib(x: int) -> int {
     match int_less(x, 2) {
         false => int_add(fib(int_sub(x, 1)), fib(int_sub(x, 2))),
         true => 1,

--- a/crates/compiler/src/tests/cases/012.src.core
+++ b/crates/compiler/src/tests/cases/012.src.core
@@ -1,4 +1,4 @@
-fn fib(x/0: Int) -> Int {
+fn fib(x/0: int) -> int {
   let mtmp0 = int_less(x/0, 2) in
   match mtmp0 {
     true => {
@@ -10,6 +10,6 @@ fn fib(x/0: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   string_print(int_to_string(fib(10)))
 }

--- a/crates/compiler/src/tests/cases/012.src.cst
+++ b/crates/compiler/src/tests/cases/012.src.cst
@@ -10,13 +10,13 @@ FILE@0..188
         Colon@8..9 ":"
         Whitespace@9..10 " "
         TYPE_INT@10..13
-          IntKeyword@10..13 "Int"
+          IntKeyword@10..13 "int"
       RParen@13..14 ")"
       Whitespace@14..15 " "
     Arrow@15..17 "->"
     Whitespace@17..18 " "
     TYPE_INT@18..22
-      IntKeyword@18..21 "Int"
+      IntKeyword@18..21 "int"
       Whitespace@21..22 " "
     BLOCK@22..133
       LBrace@22..23 "{"

--- a/crates/compiler/src/tests/cases/012.src.mono
+++ b/crates/compiler/src/tests/cases/012.src.mono
@@ -1,4 +1,4 @@
-fn fib(x/0: Int) -> Int {
+fn fib(x/0: int) -> int {
   let mtmp0 = int_less(x/0, 2) in
   match mtmp0 {
     true => {
@@ -10,6 +10,6 @@ fn fib(x/0: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   string_print(int_to_string(fib(10)))
 }

--- a/crates/compiler/src/tests/cases/012.src.tast
+++ b/crates/compiler/src/tests/cases/012.src.tast
@@ -1,10 +1,10 @@
-fn fib(x/0: Int) -> Int {
-  match int_less((x/0 : Int), 2) {
-      false => int_add(fib(int_sub((x/0 : Int), 1)), fib(int_sub((x/0 : Int), 2))),
+fn fib(x/0: int) -> int {
+  match int_less((x/0 : int), 2) {
+      false => int_add(fib(int_sub((x/0 : int), 1)), fib(int_sub((x/0 : int), 2))),
       true => 1,
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   string_print(int_to_string(fib(10)))
 }

--- a/crates/compiler/src/tests/cases/013.src.anf
+++ b/crates/compiler/src/tests/cases/013.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let s/0 = "abcde" in
   let mtmp0 = string_println(s/0) in
   let mtmp1 = string_print(s/0) in

--- a/crates/compiler/src/tests/cases/013.src.core
+++ b/crates/compiler/src/tests/cases/013.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let s/0 = "abcde" in
   let mtmp0 = string_println(s/0) in
   let mtmp1 = string_print(s/0) in

--- a/crates/compiler/src/tests/cases/013.src.mono
+++ b/crates/compiler/src/tests/cases/013.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let s/0 = "abcde" in
   let mtmp0 = string_println(s/0) in
   let mtmp1 = string_print(s/0) in

--- a/crates/compiler/src/tests/cases/013.src.tast
+++ b/crates/compiler/src/tests/cases/013.src.tast
@@ -1,6 +1,6 @@
-fn main() -> Unit {
-  let s/0: String = "abcde" in
-  let _ : Unit = string_println((s/0 : String)) in
-  let _ : Unit = string_print((s/0 : String)) in
+fn main() -> unit {
+  let s/0: string = "abcde" in
+  let _ : unit = string_println((s/0 : string)) in
+  let _ : unit = string_print((s/0 : string)) in
   ()
 }

--- a/crates/compiler/src/tests/cases/014.src
+++ b/crates/compiler/src/tests/cases/014.src
@@ -1,4 +1,4 @@
-fn test_nested_match(x: (Bool, Bool), y: (Bool, Bool)) {
+fn test_nested_match(x: (bool, bool), y: (bool, bool)) {
   match x {
     (true, false) => 
       match y {

--- a/crates/compiler/src/tests/cases/014.src.anf
+++ b/crates/compiler/src/tests/cases/014.src.anf
@@ -1,4 +1,4 @@
-fn test_nested_match(x/0: (Bool, Bool), y/1: (Bool, Bool)) -> Unit {
+fn test_nested_match(x/0: (bool, bool), y/1: (bool, bool)) -> unit {
   let x0 = x/0.0 in
   let x1 = x/0.1 in
   match x1 {
@@ -66,7 +66,7 @@ fn test_nested_match(x/0: (Bool, Bool), y/1: (Bool, Bool)) -> Unit {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t12 = (true, false) in
   let t13 = (false, true) in
   let mtmp8 = test_nested_match(t12, t13) in

--- a/crates/compiler/src/tests/cases/014.src.ast
+++ b/crates/compiler/src/tests/cases/014.src.ast
@@ -1,4 +1,4 @@
-fn test_nested_match(x: (Bool, Bool), y: (Bool, Bool)) {
+fn test_nested_match(x: (bool, bool), y: (bool, bool)) {
     match x {
         (true, false) => match y {
               (false, true) => string_println("case1"),

--- a/crates/compiler/src/tests/cases/014.src.core
+++ b/crates/compiler/src/tests/cases/014.src.core
@@ -1,4 +1,4 @@
-fn test_nested_match(x/0: (Bool, Bool), y/1: (Bool, Bool)) -> Unit {
+fn test_nested_match(x/0: (bool, bool), y/1: (bool, bool)) -> unit {
   let x0 = x/0.0 in
   let x1 = x/0.1 in
   match x1 {
@@ -66,7 +66,7 @@ fn test_nested_match(x/0: (Bool, Bool), y/1: (Bool, Bool)) -> Unit {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp8 = test_nested_match((true, false), (false, true)) in
   let mtmp9 = test_nested_match((true, false), (true, false)) in
   let mtmp10 = test_nested_match((false, true), (false, true)) in

--- a/crates/compiler/src/tests/cases/014.src.cst
+++ b/crates/compiler/src/tests/cases/014.src.cst
@@ -13,11 +13,11 @@ FILE@0..599
           TYPE_LIST@24..36
             LParen@24..25 "("
             TYPE_BOOL@25..29
-              BoolKeyword@25..29 "Bool"
+              BoolKeyword@25..29 "bool"
             Comma@29..30 ","
             Whitespace@30..31 " "
             TYPE_BOOL@31..35
-              BoolKeyword@31..35 "Bool"
+              BoolKeyword@31..35 "bool"
             RParen@35..36 ")"
         Comma@36..37 ","
         Whitespace@37..38 " "
@@ -29,11 +29,11 @@ FILE@0..599
           TYPE_LIST@41..53
             LParen@41..42 "("
             TYPE_BOOL@42..46
-              BoolKeyword@42..46 "Bool"
+              BoolKeyword@42..46 "bool"
             Comma@46..47 ","
             Whitespace@47..48 " "
             TYPE_BOOL@48..52
-              BoolKeyword@48..52 "Bool"
+              BoolKeyword@48..52 "bool"
             RParen@52..53 ")"
       RParen@53..54 ")"
       Whitespace@54..55 " "

--- a/crates/compiler/src/tests/cases/014.src.mono
+++ b/crates/compiler/src/tests/cases/014.src.mono
@@ -1,4 +1,4 @@
-fn test_nested_match(x/0: (Bool, Bool), y/1: (Bool, Bool)) -> Unit {
+fn test_nested_match(x/0: (bool, bool), y/1: (bool, bool)) -> unit {
   let x0 = x/0.0 in
   let x1 = x/0.1 in
   match x1 {
@@ -66,7 +66,7 @@ fn test_nested_match(x/0: (Bool, Bool), y/1: (Bool, Bool)) -> Unit {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp8 = test_nested_match((true, false), (false, true)) in
   let mtmp9 = test_nested_match((true, false), (true, false)) in
   let mtmp10 = test_nested_match((false, true), (false, true)) in

--- a/crates/compiler/src/tests/cases/014.src.tast
+++ b/crates/compiler/src/tests/cases/014.src.tast
@@ -1,20 +1,20 @@
-fn test_nested_match(x/0: (Bool, Bool), y/1: (Bool, Bool)) -> Unit {
-  match (x/0 : (Bool, Bool)) {
-      (true, false) => match (y/1 : (Bool, Bool)) {
+fn test_nested_match(x/0: (bool, bool), y/1: (bool, bool)) -> unit {
+  match (x/0 : (bool, bool)) {
+      (true, false) => match (y/1 : (bool, bool)) {
             (false, true) => string_println("case1"),
-            _ : (Bool, Bool) => string_println("case2"),
+            _ : (bool, bool) => string_println("case2"),
         },
-      _ : (Bool, Bool) => match (y/1 : (Bool, Bool)) {
+      _ : (bool, bool) => match (y/1 : (bool, bool)) {
             (false, true) => string_println("case3"),
-            _ : (Bool, Bool) => string_println("case4"),
+            _ : (bool, bool) => string_println("case4"),
         },
   }
 }
 
-fn main() -> Unit {
-  let _ : Unit = test_nested_match((true, false), (false, true)) in
-  let _ : Unit = test_nested_match((true, false), (true, false)) in
-  let _ : Unit = test_nested_match((false, true), (false, true)) in
-  let _ : Unit = test_nested_match((false, true), (true, false)) in
+fn main() -> unit {
+  let _ : unit = test_nested_match((true, false), (false, true)) in
+  let _ : unit = test_nested_match((true, false), (true, false)) in
+  let _ : unit = test_nested_match((false, true), (false, true)) in
+  let _ : unit = test_nested_match((false, true), (true, false)) in
   ()
 }

--- a/crates/compiler/src/tests/cases/015.src
+++ b/crates/compiler/src/tests/cases/015.src
@@ -1,6 +1,6 @@
 enum IntList {
     Nil,
-    Cons(Int, IntList),
+    Cons(int, IntList),
 }
 
 fn print_int_list(xs: IntList) {
@@ -29,7 +29,7 @@ fn int_list_rev(xs: IntList) -> IntList {
 }
 
 
-fn int_list_length(xs: IntList) -> Int {
+fn int_list_length(xs: IntList) -> int {
     match xs {
         Nil => 0,
         Cons(_, xs) => int_add(1, int_list_length(xs)),

--- a/crates/compiler/src/tests/cases/015.src.anf
+++ b/crates/compiler/src/tests/cases/015.src.anf
@@ -1,4 +1,4 @@
-fn print_int_list(xs/0: IntList) -> Unit {
+fn print_int_list(xs/0: IntList) -> unit {
   match xs/0 {
     Tag_0 => {
       string_print("Nil")
@@ -41,7 +41,7 @@ fn int_list_rev(xs/7: IntList) -> IntList {
   int_list_rev_aux(xs/7, t27)
 }
 
-fn int_list_length(xs/8: IntList) -> Int {
+fn int_list_length(xs/8: IntList) -> int {
   match xs/8 {
     Tag_0 => {
       0
@@ -56,7 +56,7 @@ fn int_list_length(xs/8: IntList) -> Int {
   }
 }
 
-fn print_int_list_length(xs/10: IntList) -> Unit {
+fn print_int_list_length(xs/10: IntList) -> unit {
   let mtmp12 = string_print("Length: ") in
   let t30 = int_list_length(xs/10) in
   let t29 = int_to_string(t30) in
@@ -64,7 +64,7 @@ fn print_int_list_length(xs/10: IntList) -> Unit {
   ()
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let x/11 = Tag_0 in
   let mtmp14 = print_int_list(x/11) in
   let mtmp15 = string_println("") in

--- a/crates/compiler/src/tests/cases/015.src.ast
+++ b/crates/compiler/src/tests/cases/015.src.ast
@@ -1,6 +1,6 @@
 enum IntList {
     Nil,
-    Cons(Int, IntList)
+    Cons(int, IntList)
 }
 
 fn print_int_list(xs: IntList) {
@@ -27,7 +27,7 @@ fn int_list_rev(xs: IntList) -> IntList {
     int_list_rev_aux(xs, Nil)
 }
 
-fn int_list_length(xs: IntList) -> Int {
+fn int_list_length(xs: IntList) -> int {
     match xs {
         Nil => 0,
         Cons(_, xs) => int_add(1, int_list_length(xs)),

--- a/crates/compiler/src/tests/cases/015.src.core
+++ b/crates/compiler/src/tests/cases/015.src.core
@@ -1,4 +1,4 @@
-fn print_int_list(xs/0: IntList) -> Unit {
+fn print_int_list(xs/0: IntList) -> unit {
   match xs/0 {
     IntList::Nil => {
       string_print("Nil")
@@ -38,7 +38,7 @@ fn int_list_rev(xs/7: IntList) -> IntList {
   int_list_rev_aux(xs/7, IntList::Nil)
 }
 
-fn int_list_length(xs/8: IntList) -> Int {
+fn int_list_length(xs/8: IntList) -> int {
   match xs/8 {
     IntList::Nil => {
       0
@@ -52,13 +52,13 @@ fn int_list_length(xs/8: IntList) -> Int {
   }
 }
 
-fn print_int_list_length(xs/10: IntList) -> Unit {
+fn print_int_list_length(xs/10: IntList) -> unit {
   let mtmp12 = string_print("Length: ") in
   let mtmp13 = string_println(int_to_string(int_list_length(xs/10))) in
   ()
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let x/11 = IntList::Nil in
   let mtmp14 = print_int_list(x/11) in
   let mtmp15 = string_println("") in

--- a/crates/compiler/src/tests/cases/015.src.cst
+++ b/crates/compiler/src/tests/cases/015.src.cst
@@ -16,7 +16,7 @@ FILE@0..1527
         TYPE_LIST@32..46
           LParen@32..33 "("
           TYPE_INT@33..36
-            IntKeyword@33..36 "Int"
+            IntKeyword@33..36 "int"
           Comma@36..37 ","
           Whitespace@37..38 " "
           TYPE_TAPP@38..45
@@ -381,7 +381,7 @@ FILE@0..1527
     Arrow@728..730 "->"
     Whitespace@730..731 " "
     TYPE_INT@731..735
-      IntKeyword@731..734 "Int"
+      IntKeyword@731..734 "int"
       Whitespace@734..735 " "
     BLOCK@735..835
       LBrace@735..736 "{"

--- a/crates/compiler/src/tests/cases/015.src.mono
+++ b/crates/compiler/src/tests/cases/015.src.mono
@@ -1,4 +1,4 @@
-fn print_int_list(xs/0: IntList) -> Unit {
+fn print_int_list(xs/0: IntList) -> unit {
   match xs/0 {
     IntList::Nil => {
       string_print("Nil")
@@ -38,7 +38,7 @@ fn int_list_rev(xs/7: IntList) -> IntList {
   int_list_rev_aux(xs/7, IntList::Nil)
 }
 
-fn int_list_length(xs/8: IntList) -> Int {
+fn int_list_length(xs/8: IntList) -> int {
   match xs/8 {
     IntList::Nil => {
       0
@@ -52,13 +52,13 @@ fn int_list_length(xs/8: IntList) -> Int {
   }
 }
 
-fn print_int_list_length(xs/10: IntList) -> Unit {
+fn print_int_list_length(xs/10: IntList) -> unit {
   let mtmp12 = string_print("Length: ") in
   let mtmp13 = string_println(int_to_string(int_list_length(xs/10))) in
   ()
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let x/11 = IntList::Nil in
   let mtmp14 = print_int_list(x/11) in
   let mtmp15 = string_println("") in

--- a/crates/compiler/src/tests/cases/015.src.tast
+++ b/crates/compiler/src/tests/cases/015.src.tast
@@ -1,12 +1,12 @@
-fn print_int_list(xs/0: IntList) -> Unit {
+fn print_int_list(xs/0: IntList) -> unit {
   match (xs/0 : IntList) {
       IntList::Nil => string_print("Nil"),
-      IntList::Cons(x/1: Int, xs/2: IntList) => let _ : Unit = string_print("Cons") in
-        let _ : Unit = string_print("(") in
-        let _ : Unit = string_print(int_to_string((x/1 : Int))) in
-        let _ : Unit = string_print(", ") in
-        let _ : Unit = print_int_list((xs/2 : IntList)) in
-        let _ : Unit = string_print(")") in
+      IntList::Cons(x/1: int, xs/2: IntList) => let _ : unit = string_print("Cons") in
+        let _ : unit = string_print("(") in
+        let _ : unit = string_print(int_to_string((x/1 : int))) in
+        let _ : unit = string_print(", ") in
+        let _ : unit = print_int_list((xs/2 : IntList)) in
+        let _ : unit = string_print(")") in
         (),
   }
 }
@@ -14,7 +14,7 @@ fn print_int_list(xs/0: IntList) -> Unit {
 fn int_list_rev_aux(xs/3: IntList, acc/4: IntList) -> IntList {
   match (xs/3 : IntList) {
       IntList::Nil => (acc/4 : IntList),
-      IntList::Cons(head/5: Int, tail/6: IntList) => int_list_rev_aux((tail/6 : IntList), IntList::Cons((head/5 : Int), (acc/4 : IntList))),
+      IntList::Cons(head/5: int, tail/6: IntList) => int_list_rev_aux((tail/6 : IntList), IntList::Cons((head/5 : int), (acc/4 : IntList))),
   }
 }
 
@@ -22,34 +22,34 @@ fn int_list_rev(xs/7: IntList) -> IntList {
   int_list_rev_aux((xs/7 : IntList), IntList::Nil)
 }
 
-fn int_list_length(xs/8: IntList) -> Int {
+fn int_list_length(xs/8: IntList) -> int {
   match (xs/8 : IntList) {
       IntList::Nil => 0,
-      IntList::Cons(_ : Int, xs/9: IntList) => int_add(1, int_list_length((xs/9 : IntList))),
+      IntList::Cons(_ : int, xs/9: IntList) => int_add(1, int_list_length((xs/9 : IntList))),
   }
 }
 
-fn print_int_list_length(xs/10: IntList) -> Unit {
-  let _ : Unit = string_print("Length: ") in
-  let _ : Unit = string_println(int_to_string(int_list_length((xs/10 : IntList)))) in
+fn print_int_list_length(xs/10: IntList) -> unit {
+  let _ : unit = string_print("Length: ") in
+  let _ : unit = string_println(int_to_string(int_list_length((xs/10 : IntList)))) in
   ()
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let x/11: IntList = IntList::Nil in
-  let _ : Unit = print_int_list((x/11 : IntList)) in
-  let _ : Unit = string_println("") in
-  let _ : Unit = print_int_list_length((x/11 : IntList)) in
+  let _ : unit = print_int_list((x/11 : IntList)) in
+  let _ : unit = string_println("") in
+  let _ : unit = print_int_list_length((x/11 : IntList)) in
   let x/12: IntList = IntList::Cons(1, IntList::Nil) in
-  let _ : Unit = print_int_list((x/12 : IntList)) in
-  let _ : Unit = string_println("") in
-  let _ : Unit = print_int_list_length((x/12 : IntList)) in
+  let _ : unit = print_int_list((x/12 : IntList)) in
+  let _ : unit = string_println("") in
+  let _ : unit = print_int_list_length((x/12 : IntList)) in
   let x/13: IntList = IntList::Cons(1, IntList::Cons(2, IntList::Cons(3, IntList::Nil))) in
-  let _ : Unit = print_int_list((x/13 : IntList)) in
-  let _ : Unit = string_println("") in
-  let _ : Unit = print_int_list_length((x/13 : IntList)) in
+  let _ : unit = print_int_list((x/13 : IntList)) in
+  let _ : unit = string_println("") in
+  let _ : unit = print_int_list_length((x/13 : IntList)) in
   let y/14: IntList = int_list_rev((x/13 : IntList)) in
-  let _ : Unit = print_int_list((y/14 : IntList)) in
-  let _ : Unit = string_println("") in
+  let _ : unit = print_int_list((y/14 : IntList)) in
+  let _ : unit = string_println("") in
   ()
 }

--- a/crates/compiler/src/tests/cases/016.src
+++ b/crates/compiler/src/tests/cases/016.src
@@ -3,14 +3,14 @@ enum List[T] {
     Cons(T, List[T]),
 }
 
-fn list_length[T](xs: List[T]) -> Int {
+fn list_length[T](xs: List[T]) -> int {
     match xs {
         Nil => 0,
         Cons(_, tail) => int_add(1, list_length(tail)),
     }
 }
 
-fn int_list_length(xs: List[Int]) -> Int {
+fn int_list_length(xs: List[int]) -> int {
     match xs {
         Nil => 0,
         Cons(_, tail) => int_add(1, int_list_length(tail)),

--- a/crates/compiler/src/tests/cases/016.src.anf
+++ b/crates/compiler/src/tests/cases/016.src.anf
@@ -1,11 +1,11 @@
-fn int_list_length(xs/2: List__Int) -> Int {
+fn int_list_length(xs/2: List__int) -> int {
   match xs/2 {
     Tag_0 => {
       0
     },
     Tag_1 => {
-      let x2 = List__Int::Cons._0(xs/2) in
-      let x3 = List__Int::Cons._1(xs/2) in
+      let x2 = List__int::Cons._0(xs/2) in
+      let x3 = List__int::Cons._1(xs/2) in
       let tail/3 = x3 in
       let t10 = int_list_length(tail/3) in
       int_add(1, t10)
@@ -13,85 +13,85 @@ fn int_list_length(xs/2: List__Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t11 = Tag_0 in
-  let x/4 = List__Int::Cons(1, t11) in
-  let length/5 = list_length__T_Int(x/4) in
+  let x/4 = List__int::Cons(1, t11) in
+  let length/5 = list_length__T_int(x/4) in
   let t12 = int_to_string(length/5) in
   let mtmp4 = string_println(t12) in
   let t14 = Tag_0 in
-  let t13 = List__Int::Cons(2, t14) in
-  let x/6 = List__Int::Cons(1, t13) in
-  let length/7 = list_length__T_Int(x/6) in
+  let t13 = List__int::Cons(2, t14) in
+  let x/6 = List__int::Cons(1, t13) in
+  let length/7 = list_length__T_int(x/6) in
   let t15 = int_to_string(length/7) in
   let mtmp5 = string_println(t15) in
   let t18 = Tag_0 in
-  let t17 = List__Int::Cons(2, t18) in
-  let t16 = List__Int::Cons(1, t17) in
-  let x/8 = List__Int::Cons(0, t16) in
+  let t17 = List__int::Cons(2, t18) in
+  let t16 = List__int::Cons(1, t17) in
+  let x/8 = List__int::Cons(0, t16) in
   let length/9 = int_list_length(x/8) in
   let t19 = int_to_string(length/9) in
   let mtmp6 = string_println(t19) in
   let t20 = Tag_0 in
-  let x/10 = List__Unit::Cons((), t20) in
-  let length/11 = list_length__T_Unit(x/10) in
+  let x/10 = List__unit::Cons((), t20) in
+  let length/11 = list_length__T_unit(x/10) in
   let t21 = int_to_string(length/11) in
   let mtmp7 = string_println(t21) in
   let t23 = Tag_0 in
-  let t22 = List__Unit::Cons((), t23) in
-  let x/12 = List__Unit::Cons((), t22) in
-  let length/13 = list_length__T_Unit(x/12) in
+  let t22 = List__unit::Cons((), t23) in
+  let x/12 = List__unit::Cons((), t22) in
+  let length/13 = list_length__T_unit(x/12) in
   let t24 = int_to_string(length/13) in
   let mtmp8 = string_println(t24) in
   let t26 = Tag_0 in
-  let t25 = List__Bool::Cons(false, t26) in
-  let x/14 = List__Bool::Cons(true, t25) in
-  let length/15 = list_length__T_Bool(x/14) in
+  let t25 = List__bool::Cons(false, t26) in
+  let x/14 = List__bool::Cons(true, t25) in
+  let length/15 = list_length__T_bool(x/14) in
   let t27 = int_to_string(length/15) in
   let mtmp9 = string_println(t27) in
   ()
 }
 
-fn list_length__T_Int(xs/0: List__Int) -> Int {
+fn list_length__T_int(xs/0: List__int) -> int {
   match xs/0 {
     Tag_0 => {
       0
     },
     Tag_1 => {
-      let x0 = List__Int::Cons._0(xs/0) in
-      let x1 = List__Int::Cons._1(xs/0) in
+      let x0 = List__int::Cons._0(xs/0) in
+      let x1 = List__int::Cons._1(xs/0) in
       let tail/1 = x1 in
-      let t28 = list_length__T_Int(tail/1) in
+      let t28 = list_length__T_int(tail/1) in
       int_add(1, t28)
     },
   }
 }
 
-fn list_length__T_Unit(xs/0: List__Unit) -> Int {
+fn list_length__T_unit(xs/0: List__unit) -> int {
   match xs/0 {
     Tag_0 => {
       0
     },
     Tag_1 => {
-      let x0 = List__Unit::Cons._0(xs/0) in
-      let x1 = List__Unit::Cons._1(xs/0) in
+      let x0 = List__unit::Cons._0(xs/0) in
+      let x1 = List__unit::Cons._1(xs/0) in
       let tail/1 = x1 in
-      let t29 = list_length__T_Unit(tail/1) in
+      let t29 = list_length__T_unit(tail/1) in
       int_add(1, t29)
     },
   }
 }
 
-fn list_length__T_Bool(xs/0: List__Bool) -> Int {
+fn list_length__T_bool(xs/0: List__bool) -> int {
   match xs/0 {
     Tag_0 => {
       0
     },
     Tag_1 => {
-      let x0 = List__Bool::Cons._0(xs/0) in
-      let x1 = List__Bool::Cons._1(xs/0) in
+      let x0 = List__bool::Cons._0(xs/0) in
+      let x1 = List__bool::Cons._1(xs/0) in
       let tail/1 = x1 in
-      let t30 = list_length__T_Bool(tail/1) in
+      let t30 = list_length__T_bool(tail/1) in
       int_add(1, t30)
     },
   }

--- a/crates/compiler/src/tests/cases/016.src.ast
+++ b/crates/compiler/src/tests/cases/016.src.ast
@@ -3,14 +3,14 @@ enum List {
     Cons(T, List[T])
 }
 
-fn list_length(xs: List[T]) -> Int {
+fn list_length(xs: List[T]) -> int {
     match xs {
         Nil => 0,
         Cons(_, tail) => int_add(1, list_length(tail)),
     }
 }
 
-fn int_list_length(xs: List[Int]) -> Int {
+fn int_list_length(xs: List[int]) -> int {
     match xs {
         Nil => 0,
         Cons(_, tail) => int_add(1, int_list_length(tail)),

--- a/crates/compiler/src/tests/cases/016.src.core
+++ b/crates/compiler/src/tests/cases/016.src.core
@@ -1,4 +1,4 @@
-fn list_length(xs/0: List[T]) -> Int {
+fn list_length(xs/0: List[T]) -> int {
   match xs/0 {
     List::Nil => {
       0
@@ -12,7 +12,7 @@ fn list_length(xs/0: List[T]) -> Int {
   }
 }
 
-fn int_list_length(xs/2: List[Int]) -> Int {
+fn int_list_length(xs/2: List[int]) -> int {
   match xs/2 {
     List::Nil => {
       0
@@ -26,7 +26,7 @@ fn int_list_length(xs/2: List[Int]) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let x/4 = List::Cons(1, List::Nil) in
   let length/5 = list_length(x/4) in
   let mtmp4 = string_println(int_to_string(length/5)) in

--- a/crates/compiler/src/tests/cases/016.src.cst
+++ b/crates/compiler/src/tests/cases/016.src.cst
@@ -63,7 +63,7 @@ FILE@0..1113
     Arrow@80..82 "->"
     Whitespace@82..83 " "
     TYPE_INT@83..87
-      IntKeyword@83..86 "Int"
+      IntKeyword@83..86 "int"
       Whitespace@86..87 " "
     BLOCK@87..187
       LBrace@87..88 "{"
@@ -143,14 +143,14 @@ FILE@0..1113
           TYPE_PARAM_LIST@214..219
             LBracket@214..215 "["
             TYPE_INT@215..218
-              IntKeyword@215..218 "Int"
+              IntKeyword@215..218 "int"
             RBracket@218..219 "]"
       RParen@219..220 ")"
       Whitespace@220..221 " "
     Arrow@221..223 "->"
     Whitespace@223..224 " "
     TYPE_INT@224..228
-      IntKeyword@224..227 "Int"
+      IntKeyword@224..227 "int"
       Whitespace@227..228 " "
     BLOCK@228..332
       LBrace@228..229 "{"

--- a/crates/compiler/src/tests/cases/016.src.gom
+++ b/crates/compiler/src/tests/cases/016.src.gom
@@ -51,59 +51,59 @@ func missing(s string) struct{} {
     return struct{}{}
 }
 
-type List__Int interface {
-    isList__Int()
+type List__int interface {
+    isList__int()
 }
 
-type List__Int_Nil struct {}
+type List__int_Nil struct {}
 
-func (_ List__Int_Nil) isList__Int() {}
+func (_ List__int_Nil) isList__int() {}
 
-type List__Int_Cons struct {
+type List__int_Cons struct {
     _0 int
-    _1 List__Int
+    _1 List__int
 }
 
-func (_ List__Int_Cons) isList__Int() {}
+func (_ List__int_Cons) isList__int() {}
 
-type List__Unit interface {
-    isList__Unit()
+type List__unit interface {
+    isList__unit()
 }
 
-type List__Unit_Nil struct {}
+type List__unit_Nil struct {}
 
-func (_ List__Unit_Nil) isList__Unit() {}
+func (_ List__unit_Nil) isList__unit() {}
 
-type List__Unit_Cons struct {
+type List__unit_Cons struct {
     _0 struct{}
-    _1 List__Unit
+    _1 List__unit
 }
 
-func (_ List__Unit_Cons) isList__Unit() {}
+func (_ List__unit_Cons) isList__unit() {}
 
-type List__Bool interface {
-    isList__Bool()
+type List__bool interface {
+    isList__bool()
 }
 
-type List__Bool_Nil struct {}
+type List__bool_Nil struct {}
 
-func (_ List__Bool_Nil) isList__Bool() {}
+func (_ List__bool_Nil) isList__bool() {}
 
-type List__Bool_Cons struct {
+type List__bool_Cons struct {
     _0 bool
-    _1 List__Bool
+    _1 List__bool
 }
 
-func (_ List__Bool_Cons) isList__Bool() {}
+func (_ List__bool_Cons) isList__bool() {}
 
-func int_list_length(xs__2 List__Int) int {
+func int_list_length(xs__2 List__int) int {
     var ret31 int
     switch xs__2 := xs__2.(type) {
-    case List__Int_Nil:
+    case List__int_Nil:
         ret31 = 0
-    case List__Int_Cons:
-        var x3 List__Int = xs__2._1
-        var tail__3 List__Int = x3
+    case List__int_Cons:
+        var x3 List__int = xs__2._1
+        var tail__3 List__int = x3
         var t10 int = int_list_length(tail__3)
         ret31 = int_add(1, t10)
     }
@@ -112,115 +112,115 @@ func int_list_length(xs__2 List__Int) int {
 
 func main0() struct{} {
     var ret32 struct{}
-    var t11 List__Int = List__Int_Nil{}
-    var x__4 List__Int = List__Int_Cons{
+    var t11 List__int = List__int_Nil{}
+    var x__4 List__int = List__int_Cons{
         _0: 1,
         _1: t11,
     }
-    var length__5 int = list_length__T_Int(x__4)
+    var length__5 int = list_length__T_int(x__4)
     var t12 string = int_to_string(length__5)
     string_println(t12)
-    var t14 List__Int = List__Int_Nil{}
-    var t13 List__Int = List__Int_Cons{
+    var t14 List__int = List__int_Nil{}
+    var t13 List__int = List__int_Cons{
         _0: 2,
         _1: t14,
     }
-    var x__6 List__Int = List__Int_Cons{
+    var x__6 List__int = List__int_Cons{
         _0: 1,
         _1: t13,
     }
-    var length__7 int = list_length__T_Int(x__6)
+    var length__7 int = list_length__T_int(x__6)
     var t15 string = int_to_string(length__7)
     string_println(t15)
-    var t18 List__Int = List__Int_Nil{}
-    var t17 List__Int = List__Int_Cons{
+    var t18 List__int = List__int_Nil{}
+    var t17 List__int = List__int_Cons{
         _0: 2,
         _1: t18,
     }
-    var t16 List__Int = List__Int_Cons{
+    var t16 List__int = List__int_Cons{
         _0: 1,
         _1: t17,
     }
-    var x__8 List__Int = List__Int_Cons{
+    var x__8 List__int = List__int_Cons{
         _0: 0,
         _1: t16,
     }
     var length__9 int = int_list_length(x__8)
     var t19 string = int_to_string(length__9)
     string_println(t19)
-    var t20 List__Unit = List__Unit_Nil{}
-    var x__10 List__Unit = List__Unit_Cons{
+    var t20 List__unit = List__unit_Nil{}
+    var x__10 List__unit = List__unit_Cons{
         _0: struct{}{},
         _1: t20,
     }
-    var length__11 int = list_length__T_Unit(x__10)
+    var length__11 int = list_length__T_unit(x__10)
     var t21 string = int_to_string(length__11)
     string_println(t21)
-    var t23 List__Unit = List__Unit_Nil{}
-    var t22 List__Unit = List__Unit_Cons{
+    var t23 List__unit = List__unit_Nil{}
+    var t22 List__unit = List__unit_Cons{
         _0: struct{}{},
         _1: t23,
     }
-    var x__12 List__Unit = List__Unit_Cons{
+    var x__12 List__unit = List__unit_Cons{
         _0: struct{}{},
         _1: t22,
     }
-    var length__13 int = list_length__T_Unit(x__12)
+    var length__13 int = list_length__T_unit(x__12)
     var t24 string = int_to_string(length__13)
     string_println(t24)
-    var t26 List__Bool = List__Bool_Nil{}
-    var t25 List__Bool = List__Bool_Cons{
+    var t26 List__bool = List__bool_Nil{}
+    var t25 List__bool = List__bool_Cons{
         _0: false,
         _1: t26,
     }
-    var x__14 List__Bool = List__Bool_Cons{
+    var x__14 List__bool = List__bool_Cons{
         _0: true,
         _1: t25,
     }
-    var length__15 int = list_length__T_Bool(x__14)
+    var length__15 int = list_length__T_bool(x__14)
     var t27 string = int_to_string(length__15)
     string_println(t27)
     ret32 = struct{}{}
     return ret32
 }
 
-func list_length__T_Int(xs__0 List__Int) int {
+func list_length__T_int(xs__0 List__int) int {
     var ret33 int
     switch xs__0 := xs__0.(type) {
-    case List__Int_Nil:
+    case List__int_Nil:
         ret33 = 0
-    case List__Int_Cons:
-        var x1 List__Int = xs__0._1
-        var tail__1 List__Int = x1
-        var t28 int = list_length__T_Int(tail__1)
+    case List__int_Cons:
+        var x1 List__int = xs__0._1
+        var tail__1 List__int = x1
+        var t28 int = list_length__T_int(tail__1)
         ret33 = int_add(1, t28)
     }
     return ret33
 }
 
-func list_length__T_Unit(xs__0 List__Unit) int {
+func list_length__T_unit(xs__0 List__unit) int {
     var ret34 int
     switch xs__0 := xs__0.(type) {
-    case List__Unit_Nil:
+    case List__unit_Nil:
         ret34 = 0
-    case List__Unit_Cons:
-        var x1 List__Unit = xs__0._1
-        var tail__1 List__Unit = x1
-        var t29 int = list_length__T_Unit(tail__1)
+    case List__unit_Cons:
+        var x1 List__unit = xs__0._1
+        var tail__1 List__unit = x1
+        var t29 int = list_length__T_unit(tail__1)
         ret34 = int_add(1, t29)
     }
     return ret34
 }
 
-func list_length__T_Bool(xs__0 List__Bool) int {
+func list_length__T_bool(xs__0 List__bool) int {
     var ret35 int
     switch xs__0 := xs__0.(type) {
-    case List__Bool_Nil:
+    case List__bool_Nil:
         ret35 = 0
-    case List__Bool_Cons:
-        var x1 List__Bool = xs__0._1
-        var tail__1 List__Bool = x1
-        var t30 int = list_length__T_Bool(tail__1)
+    case List__bool_Cons:
+        var x1 List__bool = xs__0._1
+        var tail__1 List__bool = x1
+        var t30 int = list_length__T_bool(tail__1)
         ret35 = int_add(1, t30)
     }
     return ret35

--- a/crates/compiler/src/tests/cases/016.src.mono
+++ b/crates/compiler/src/tests/cases/016.src.mono
@@ -1,77 +1,77 @@
-fn int_list_length(xs/2: List__Int) -> Int {
+fn int_list_length(xs/2: List__int) -> int {
   match xs/2 {
-    List__Int::Nil => {
+    List__int::Nil => {
       0
     },
-    List__Int::Cons(x2, x3) => {
-      let x2 = List__Int::Cons._0(xs/2) in
-      let x3 = List__Int::Cons._1(xs/2) in
+    List__int::Cons(x2, x3) => {
+      let x2 = List__int::Cons._0(xs/2) in
+      let x3 = List__int::Cons._1(xs/2) in
       let tail/3 = x3 in
       int_add(1, int_list_length(tail/3))
     },
   }
 }
 
-fn main() -> Unit {
-  let x/4 = List__Int::Cons(1, List__Int::Nil) in
-  let length/5 = list_length__T_Int(x/4) in
+fn main() -> unit {
+  let x/4 = List__int::Cons(1, List__int::Nil) in
+  let length/5 = list_length__T_int(x/4) in
   let mtmp4 = string_println(int_to_string(length/5)) in
-  let x/6 = List__Int::Cons(1, List__Int::Cons(2, List__Int::Nil)) in
-  let length/7 = list_length__T_Int(x/6) in
+  let x/6 = List__int::Cons(1, List__int::Cons(2, List__int::Nil)) in
+  let length/7 = list_length__T_int(x/6) in
   let mtmp5 = string_println(int_to_string(length/7)) in
-  let x/8 = List__Int::Cons(0, List__Int::Cons(1, List__Int::Cons(2, List__Int::Nil))) in
+  let x/8 = List__int::Cons(0, List__int::Cons(1, List__int::Cons(2, List__int::Nil))) in
   let length/9 = int_list_length(x/8) in
   let mtmp6 = string_println(int_to_string(length/9)) in
-  let x/10 = List__Unit::Cons((), List__Unit::Nil) in
-  let length/11 = list_length__T_Unit(x/10) in
+  let x/10 = List__unit::Cons((), List__unit::Nil) in
+  let length/11 = list_length__T_unit(x/10) in
   let mtmp7 = string_println(int_to_string(length/11)) in
-  let x/12 = List__Unit::Cons((), List__Unit::Cons((), List__Unit::Nil)) in
-  let length/13 = list_length__T_Unit(x/12) in
+  let x/12 = List__unit::Cons((), List__unit::Cons((), List__unit::Nil)) in
+  let length/13 = list_length__T_unit(x/12) in
   let mtmp8 = string_println(int_to_string(length/13)) in
-  let x/14 = List__Bool::Cons(true, List__Bool::Cons(false, List__Bool::Nil)) in
-  let length/15 = list_length__T_Bool(x/14) in
+  let x/14 = List__bool::Cons(true, List__bool::Cons(false, List__bool::Nil)) in
+  let length/15 = list_length__T_bool(x/14) in
   let mtmp9 = string_println(int_to_string(length/15)) in
   ()
 }
 
-fn list_length__T_Int(xs/0: List__Int) -> Int {
+fn list_length__T_int(xs/0: List__int) -> int {
   match xs/0 {
-    List__Int::Nil => {
+    List__int::Nil => {
       0
     },
-    List__Int::Cons(x0, x1) => {
-      let x0 = List__Int::Cons._0(xs/0) in
-      let x1 = List__Int::Cons._1(xs/0) in
+    List__int::Cons(x0, x1) => {
+      let x0 = List__int::Cons._0(xs/0) in
+      let x1 = List__int::Cons._1(xs/0) in
       let tail/1 = x1 in
-      int_add(1, list_length__T_Int(tail/1))
+      int_add(1, list_length__T_int(tail/1))
     },
   }
 }
 
-fn list_length__T_Unit(xs/0: List__Unit) -> Int {
+fn list_length__T_unit(xs/0: List__unit) -> int {
   match xs/0 {
-    List__Unit::Nil => {
+    List__unit::Nil => {
       0
     },
-    List__Unit::Cons(x0, x1) => {
-      let x0 = List__Unit::Cons._0(xs/0) in
-      let x1 = List__Unit::Cons._1(xs/0) in
+    List__unit::Cons(x0, x1) => {
+      let x0 = List__unit::Cons._0(xs/0) in
+      let x1 = List__unit::Cons._1(xs/0) in
       let tail/1 = x1 in
-      int_add(1, list_length__T_Unit(tail/1))
+      int_add(1, list_length__T_unit(tail/1))
     },
   }
 }
 
-fn list_length__T_Bool(xs/0: List__Bool) -> Int {
+fn list_length__T_bool(xs/0: List__bool) -> int {
   match xs/0 {
-    List__Bool::Nil => {
+    List__bool::Nil => {
       0
     },
-    List__Bool::Cons(x0, x1) => {
-      let x0 = List__Bool::Cons._0(xs/0) in
-      let x1 = List__Bool::Cons._1(xs/0) in
+    List__bool::Cons(x0, x1) => {
+      let x0 = List__bool::Cons._0(xs/0) in
+      let x1 = List__bool::Cons._1(xs/0) in
       let tail/1 = x1 in
-      int_add(1, list_length__T_Bool(tail/1))
+      int_add(1, list_length__T_bool(tail/1))
     },
   }
 }

--- a/crates/compiler/src/tests/cases/016.src.tast
+++ b/crates/compiler/src/tests/cases/016.src.tast
@@ -1,35 +1,35 @@
-fn list_length(xs/0: List[T]) -> Int {
+fn list_length(xs/0: List[T]) -> int {
   match (xs/0 : List[T]) {
       List::Nil => 0,
       List::Cons(_ : T, tail/1: List[T]) => int_add(1, list_length((tail/1 : List[T]))),
   }
 }
 
-fn int_list_length(xs/2: List[Int]) -> Int {
-  match (xs/2 : List[Int]) {
+fn int_list_length(xs/2: List[int]) -> int {
+  match (xs/2 : List[int]) {
       List::Nil => 0,
-      List::Cons(_ : Int, tail/3: List[Int]) => int_add(1, int_list_length((tail/3 : List[Int]))),
+      List::Cons(_ : int, tail/3: List[int]) => int_add(1, int_list_length((tail/3 : List[int]))),
   }
 }
 
-fn main() -> Unit {
-  let x/4: List[Int] = List::Cons(1, List::Nil) in
-  let length/5: Int = list_length((x/4 : List[Int])) in
-  let _ : Unit = string_println(int_to_string((length/5 : Int))) in
-  let x/6: List[Int] = List::Cons(1, List::Cons(2, List::Nil)) in
-  let length/7: Int = list_length((x/6 : List[Int])) in
-  let _ : Unit = string_println(int_to_string((length/7 : Int))) in
-  let x/8: List[Int] = List::Cons(0, List::Cons(1, List::Cons(2, List::Nil))) in
-  let length/9: Int = int_list_length((x/8 : List[Int])) in
-  let _ : Unit = string_println(int_to_string((length/9 : Int))) in
-  let x/10: List[Unit] = List::Cons((), List::Nil) in
-  let length/11: Int = list_length((x/10 : List[Unit])) in
-  let _ : Unit = string_println(int_to_string((length/11 : Int))) in
-  let x/12: List[Unit] = List::Cons((), List::Cons((), List::Nil)) in
-  let length/13: Int = list_length((x/12 : List[Unit])) in
-  let _ : Unit = string_println(int_to_string((length/13 : Int))) in
-  let x/14: List[Bool] = List::Cons(true, List::Cons(false, List::Nil)) in
-  let length/15: Int = list_length((x/14 : List[Bool])) in
-  let _ : Unit = string_println(int_to_string((length/15 : Int))) in
+fn main() -> unit {
+  let x/4: List[int] = List::Cons(1, List::Nil) in
+  let length/5: int = list_length((x/4 : List[int])) in
+  let _ : unit = string_println(int_to_string((length/5 : int))) in
+  let x/6: List[int] = List::Cons(1, List::Cons(2, List::Nil)) in
+  let length/7: int = list_length((x/6 : List[int])) in
+  let _ : unit = string_println(int_to_string((length/7 : int))) in
+  let x/8: List[int] = List::Cons(0, List::Cons(1, List::Cons(2, List::Nil))) in
+  let length/9: int = int_list_length((x/8 : List[int])) in
+  let _ : unit = string_println(int_to_string((length/9 : int))) in
+  let x/10: List[unit] = List::Cons((), List::Nil) in
+  let length/11: int = list_length((x/10 : List[unit])) in
+  let _ : unit = string_println(int_to_string((length/11 : int))) in
+  let x/12: List[unit] = List::Cons((), List::Cons((), List::Nil)) in
+  let length/13: int = list_length((x/12 : List[unit])) in
+  let _ : unit = string_println(int_to_string((length/13 : int))) in
+  let x/14: List[bool] = List::Cons(true, List::Cons(false, List::Nil)) in
+  let length/15: int = list_length((x/14 : List[bool])) in
+  let _ : unit = string_println(int_to_string((length/15 : int))) in
   ()
 }

--- a/crates/compiler/src/tests/cases/017.src
+++ b/crates/compiler/src/tests/cases/017.src
@@ -1,21 +1,21 @@
 trait ToString {
-    fn to_string(Self) -> String;
+    fn to_string(Self) -> string;
 }
 
-impl ToString for Int {
-    fn to_string(self: Int) -> String {
+impl ToString for int {
+    fn to_string(self: int) -> string {
         int_to_string(self)
     }
 }
 
-impl ToString for Bool  {
-    fn to_string(self: Bool) -> String {
+impl ToString for bool  {
+    fn to_string(self: bool) -> string {
         bool_to_string(self)
     }
 }
 
-impl ToString for (Int, Int) {
-  fn to_string(self: (Int, Int)) -> String {
+impl ToString for (int, int) {
+  fn to_string(self: (int, int)) -> string {
     "(?, ?)"
   }
 }

--- a/crates/compiler/src/tests/cases/017.src.anf
+++ b/crates/compiler/src/tests/cases/017.src.anf
@@ -1,21 +1,21 @@
-fn impl_ToString_Int_to_string(self/0: Int) -> String {
+fn impl_ToString_int_to_string(self/0: int) -> string {
   int_to_string(self/0)
 }
 
-fn impl_ToString_Bool_to_string(self/1: Bool) -> String {
+fn impl_ToString_bool_to_string(self/1: bool) -> string {
   bool_to_string(self/1)
 }
 
-fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (Int, Int)) -> String {
+fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (int, int)) -> string {
   "(?, ?)"
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let x/3 = 123 in
-  let t3 = impl_ToString_Int_to_string(x/3) in
+  let t3 = impl_ToString_int_to_string(x/3) in
   let mtmp0 = string_println(t3) in
   let x/4 = true in
-  let t4 = impl_ToString_Bool_to_string(x/4) in
+  let t4 = impl_ToString_bool_to_string(x/4) in
   let mtmp1 = string_println(t4) in
   let x/5 = (3, 4) in
   let t5 = impl_ToString_Tuple_TInt_TInt_to_string(x/5) in

--- a/crates/compiler/src/tests/cases/017.src.ast
+++ b/crates/compiler/src/tests/cases/017.src.ast
@@ -1,21 +1,21 @@
 trait ToString {
-  fn to_string(Self) -> String;
+  fn to_string(Self) -> string;
 }
 
-impl ToString for Int {
-  fn to_string(self: Int) -> String {
+impl ToString for int {
+  fn to_string(self: int) -> string {
       int_to_string(self)
   }
 }
 
-impl ToString for Bool {
-  fn to_string(self: Bool) -> String {
+impl ToString for bool {
+  fn to_string(self: bool) -> string {
       bool_to_string(self)
   }
 }
 
-impl ToString for (Int, Int) {
-  fn to_string(self: (Int, Int)) -> String {
+impl ToString for (int, int) {
+  fn to_string(self: (int, int)) -> string {
       "(?, ?)"
   }
 }

--- a/crates/compiler/src/tests/cases/017.src.core
+++ b/crates/compiler/src/tests/cases/017.src.core
@@ -1,20 +1,20 @@
-fn impl_ToString_Int_to_string(self/0: Int) -> String {
+fn impl_ToString_int_to_string(self/0: int) -> string {
   int_to_string(self/0)
 }
 
-fn impl_ToString_Bool_to_string(self/1: Bool) -> String {
+fn impl_ToString_bool_to_string(self/1: bool) -> string {
   bool_to_string(self/1)
 }
 
-fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (Int, Int)) -> String {
+fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (int, int)) -> string {
   "(?, ?)"
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let x/3 = 123 in
-  let mtmp0 = string_println(impl_ToString_Int_to_string(x/3)) in
+  let mtmp0 = string_println(impl_ToString_int_to_string(x/3)) in
   let x/4 = true in
-  let mtmp1 = string_println(impl_ToString_Bool_to_string(x/4)) in
+  let mtmp1 = string_println(impl_ToString_bool_to_string(x/4)) in
   let x/5 = (3, 4) in
   let mtmp2 = string_println(impl_ToString_Tuple_TInt_TInt_to_string(x/5)) in
   ()

--- a/crates/compiler/src/tests/cases/017.src.cst
+++ b/crates/compiler/src/tests/cases/017.src.cst
@@ -20,7 +20,7 @@ FILE@0..571
         Arrow@40..42 "->"
         Whitespace@42..43 " "
         TYPE_STRING@43..49
-          StringKeyword@43..49 "String"
+          StringKeyword@43..49 "string"
       Semi@49..50 ";"
       Whitespace@50..51 "\n"
       RBrace@51..52 "}"
@@ -33,7 +33,7 @@ FILE@0..571
     ForKeyword@68..71 "for"
     Whitespace@71..72 " "
     TYPE_INT@72..76
-      IntKeyword@72..75 "Int"
+      IntKeyword@72..75 "int"
       Whitespace@75..76 " "
     LBrace@76..77 "{"
     Whitespace@77..82 "\n    "
@@ -48,13 +48,13 @@ FILE@0..571
           Colon@99..100 ":"
           Whitespace@100..101 " "
           TYPE_INT@101..104
-            IntKeyword@101..104 "Int"
+            IntKeyword@101..104 "int"
         RParen@104..105 ")"
         Whitespace@105..106 " "
       Arrow@106..108 "->"
       Whitespace@108..109 " "
       TYPE_STRING@109..116
-        StringKeyword@109..115 "String"
+        StringKeyword@109..115 "string"
         Whitespace@115..116 " "
       BLOCK@116..152
         LBrace@116..117 "{"
@@ -81,7 +81,7 @@ FILE@0..571
     ForKeyword@169..172 "for"
     Whitespace@172..173 " "
     TYPE_BOOL@173..179
-      BoolKeyword@173..177 "Bool"
+      BoolKeyword@173..177 "bool"
       Whitespace@177..179 "  "
     LBrace@179..180 "{"
     Whitespace@180..185 "\n    "
@@ -96,13 +96,13 @@ FILE@0..571
           Colon@202..203 ":"
           Whitespace@203..204 " "
           TYPE_BOOL@204..208
-            BoolKeyword@204..208 "Bool"
+            BoolKeyword@204..208 "bool"
         RParen@208..209 ")"
         Whitespace@209..210 " "
       Arrow@210..212 "->"
       Whitespace@212..213 " "
       TYPE_STRING@213..220
-        StringKeyword@213..219 "String"
+        StringKeyword@213..219 "string"
         Whitespace@219..220 " "
       BLOCK@220..257
         LBrace@220..221 "{"
@@ -132,11 +132,11 @@ FILE@0..571
       TYPE_LIST@278..289
         LParen@278..279 "("
         TYPE_INT@279..282
-          IntKeyword@279..282 "Int"
+          IntKeyword@279..282 "int"
         Comma@282..283 ","
         Whitespace@283..284 " "
         TYPE_INT@284..287
-          IntKeyword@284..287 "Int"
+          IntKeyword@284..287 "int"
         RParen@287..288 ")"
         Whitespace@288..289 " "
     LBrace@289..290 "{"
@@ -155,18 +155,18 @@ FILE@0..571
             TYPE_LIST@312..322
               LParen@312..313 "("
               TYPE_INT@313..316
-                IntKeyword@313..316 "Int"
+                IntKeyword@313..316 "int"
               Comma@316..317 ","
               Whitespace@317..318 " "
               TYPE_INT@318..321
-                IntKeyword@318..321 "Int"
+                IntKeyword@318..321 "int"
               RParen@321..322 ")"
         RParen@322..323 ")"
         Whitespace@323..324 " "
       Arrow@324..326 "->"
       Whitespace@326..327 " "
       TYPE_STRING@327..334
-        StringKeyword@327..333 "String"
+        StringKeyword@327..333 "string"
         Whitespace@333..334 " "
       BLOCK@334..353
         LBrace@334..335 "{"

--- a/crates/compiler/src/tests/cases/017.src.gom
+++ b/crates/compiler/src/tests/cases/017.src.gom
@@ -56,13 +56,13 @@ type Tuple2_int_int struct {
     _1 int
 }
 
-func impl_ToString_Int_to_string(self__0 int) string {
+func impl_ToString_int_to_string(self__0 int) string {
     var ret6 string
     ret6 = int_to_string(self__0)
     return ret6
 }
 
-func impl_ToString_Bool_to_string(self__1 bool) string {
+func impl_ToString_bool_to_string(self__1 bool) string {
     var ret7 string
     ret7 = bool_to_string(self__1)
     return ret7
@@ -77,10 +77,10 @@ func impl_ToString_Tuple_TInt_TInt_to_string(self__2 Tuple2_int_int) string {
 func main0() struct{} {
     var ret9 struct{}
     var x__3 int = 123
-    var t3 string = impl_ToString_Int_to_string(x__3)
+    var t3 string = impl_ToString_int_to_string(x__3)
     string_println(t3)
     var x__4 bool = true
-    var t4 string = impl_ToString_Bool_to_string(x__4)
+    var t4 string = impl_ToString_bool_to_string(x__4)
     string_println(t4)
     var x__5 Tuple2_int_int = Tuple2_int_int{
         _0: 3,

--- a/crates/compiler/src/tests/cases/017.src.mono
+++ b/crates/compiler/src/tests/cases/017.src.mono
@@ -1,20 +1,20 @@
-fn impl_ToString_Int_to_string(self/0: Int) -> String {
+fn impl_ToString_int_to_string(self/0: int) -> string {
   int_to_string(self/0)
 }
 
-fn impl_ToString_Bool_to_string(self/1: Bool) -> String {
+fn impl_ToString_bool_to_string(self/1: bool) -> string {
   bool_to_string(self/1)
 }
 
-fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (Int, Int)) -> String {
+fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (int, int)) -> string {
   "(?, ?)"
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let x/3 = 123 in
-  let mtmp0 = string_println(impl_ToString_Int_to_string(x/3)) in
+  let mtmp0 = string_println(impl_ToString_int_to_string(x/3)) in
   let x/4 = true in
-  let mtmp1 = string_println(impl_ToString_Bool_to_string(x/4)) in
+  let mtmp1 = string_println(impl_ToString_bool_to_string(x/4)) in
   let x/5 = (3, 4) in
   let mtmp2 = string_println(impl_ToString_Tuple_TInt_TInt_to_string(x/5)) in
   ()

--- a/crates/compiler/src/tests/cases/017.src.tast
+++ b/crates/compiler/src/tests/cases/017.src.tast
@@ -1,27 +1,27 @@
-impl ToString for Int{
-  fn to_string(self/0: Int) -> String {
-    int_to_string((self/0 : Int))
+impl ToString for int{
+  fn to_string(self/0: int) -> string {
+    int_to_string((self/0 : int))
   }
 }
 
-impl ToString for Bool{
-  fn to_string(self/1: Bool) -> String {
-    bool_to_string((self/1 : Bool))
+impl ToString for bool{
+  fn to_string(self/1: bool) -> string {
+    bool_to_string((self/1 : bool))
   }
 }
 
-impl ToString for (Int, Int){
-  fn to_string(self/2: (Int, Int)) -> String {
+impl ToString for (int, int){
+  fn to_string(self/2: (int, int)) -> string {
     "(?, ?)"
   }
 }
 
-fn main() -> Unit {
-  let x/3: Int = 123 in
-  let _ : Unit = string_println(to_string((x/3 : Int))) in
-  let x/4: Bool = true in
-  let _ : Unit = string_println(to_string((x/4 : Bool))) in
-  let x/5: (Int, Int) = (3, 4) in
-  let _ : Unit = string_println(to_string((x/5 : (Int, Int)))) in
+fn main() -> unit {
+  let x/3: int = 123 in
+  let _ : unit = string_println(to_string((x/3 : int))) in
+  let x/4: bool = true in
+  let _ : unit = string_println(to_string((x/4 : bool))) in
+  let x/5: (int, int) = (3, 4) in
+  let _ : unit = string_println(to_string((x/5 : (int, int)))) in
   ()
 }

--- a/crates/compiler/src/tests/cases/018.src
+++ b/crates/compiler/src/tests/cases/018.src
@@ -1,46 +1,46 @@
 trait Arith {
-    fn add(Self, Self) -> Int;
-    fn less(Self, Self) -> Bool;
+    fn add(Self, Self) -> int;
+    fn less(Self, Self) -> bool;
 }
 
-impl Arith for Int {
-    fn add(self: Int, other: Int) -> Int {
+impl Arith for int {
+    fn add(self: int, other: int) -> int {
         int_add(self, other)
     }
 
-    fn less(self: Int, other: Int) -> Bool {
+    fn less(self: int, other: int) -> bool {
         int_less(self, other)
     }
 }
 
 trait ToString {
-    fn to_string(Self) -> String;
+    fn to_string(Self) -> string;
 }
 
-impl ToString for Int {
-    fn to_string(self: Int) -> String {
+impl ToString for int {
+    fn to_string(self: int) -> string {
         int_to_string(self)
     }
 }
 
-impl ToString for Bool {
-    fn to_string(self: Bool) -> String {
+impl ToString for bool {
+    fn to_string(self: bool) -> string {
         bool_to_string(self)
     }
 }
 
 trait Output {
-    fn output(Self) -> Unit;
+    fn output(Self) -> unit;
 }
 
-impl Output for Int {
-    fn output(self: Int) -> Unit {
+impl Output for int {
+    fn output(self: int) -> unit {
         string_println(to_string(self))
     }
 }
 
-impl Output for Bool {
-    fn output(self: Bool) -> Unit {
+impl Output for bool {
+    fn output(self: bool) -> unit {
         string_println(to_string(self))
     }
 }

--- a/crates/compiler/src/tests/cases/018.src.anf
+++ b/crates/compiler/src/tests/cases/018.src.anf
@@ -1,51 +1,51 @@
-fn impl_Arith_Int_add(self/0: Int, other/1: Int) -> Int {
+fn impl_Arith_int_add(self/0: int, other/1: int) -> int {
   int_add(self/0, other/1)
 }
 
-fn impl_Arith_Int_less(self/2: Int, other/3: Int) -> Bool {
+fn impl_Arith_int_less(self/2: int, other/3: int) -> bool {
   int_less(self/2, other/3)
 }
 
-fn impl_ToString_Int_to_string(self/4: Int) -> String {
+fn impl_ToString_int_to_string(self/4: int) -> string {
   int_to_string(self/4)
 }
 
-fn impl_ToString_Bool_to_string(self/5: Bool) -> String {
+fn impl_ToString_bool_to_string(self/5: bool) -> string {
   bool_to_string(self/5)
 }
 
-fn impl_Output_Int_output(self/6: Int) -> Unit {
-  let t4 = impl_ToString_Int_to_string(self/6) in
+fn impl_Output_int_output(self/6: int) -> unit {
+  let t4 = impl_ToString_int_to_string(self/6) in
   string_println(t4)
 }
 
-fn impl_Output_Bool_output(self/7: Bool) -> Unit {
-  let t5 = impl_ToString_Bool_to_string(self/7) in
+fn impl_Output_bool_output(self/7: bool) -> unit {
+  let t5 = impl_ToString_bool_to_string(self/7) in
   string_println(t5)
 }
 
-fn main() -> Unit {
-  let a/9 = id__T_Int(1) in
-  let b/10 = id__T_Int(2) in
-  let c/11 = impl_Arith_Int_add(a/9, b/10) in
-  let mtmp0 = impl_Output_Int_output(c/11) in
-  let a/12 = id__T_Int(3) in
-  let b/13 = id__T_Int(4) in
-  let c/14 = impl_Arith_Int_less(a/12, b/13) in
-  let mtmp1 = impl_Output_Bool_output(c/14) in
-  let mtmp2 = id__T_String("abc") in
-  let mtmp3 = id__T_Bool(true) in
+fn main() -> unit {
+  let a/9 = id__T_int(1) in
+  let b/10 = id__T_int(2) in
+  let c/11 = impl_Arith_int_add(a/9, b/10) in
+  let mtmp0 = impl_Output_int_output(c/11) in
+  let a/12 = id__T_int(3) in
+  let b/13 = id__T_int(4) in
+  let c/14 = impl_Arith_int_less(a/12, b/13) in
+  let mtmp1 = impl_Output_bool_output(c/14) in
+  let mtmp2 = id__T_string("abc") in
+  let mtmp3 = id__T_bool(true) in
   ()
 }
 
-fn id__T_Int(x/8: Int) -> Int {
+fn id__T_int(x/8: int) -> int {
   x/8
 }
 
-fn id__T_String(x/8: String) -> String {
+fn id__T_string(x/8: string) -> string {
   x/8
 }
 
-fn id__T_Bool(x/8: Bool) -> Bool {
+fn id__T_bool(x/8: bool) -> bool {
   x/8
 }

--- a/crates/compiler/src/tests/cases/018.src.ast
+++ b/crates/compiler/src/tests/cases/018.src.ast
@@ -1,45 +1,45 @@
 trait Arith {
-  fn add(Self, Self) -> Int;
-  fn less(Self, Self) -> Bool;
+  fn add(Self, Self) -> int;
+  fn less(Self, Self) -> bool;
 }
 
-impl Arith for Int {
-  fn add(self: Int, other: Int) -> Int {
+impl Arith for int {
+  fn add(self: int, other: int) -> int {
       int_add(self, other)
   }
-  fn less(self: Int, other: Int) -> Bool {
+  fn less(self: int, other: int) -> bool {
       int_less(self, other)
   }
 }
 
 trait ToString {
-  fn to_string(Self) -> String;
+  fn to_string(Self) -> string;
 }
 
-impl ToString for Int {
-  fn to_string(self: Int) -> String {
+impl ToString for int {
+  fn to_string(self: int) -> string {
       int_to_string(self)
   }
 }
 
-impl ToString for Bool {
-  fn to_string(self: Bool) -> String {
+impl ToString for bool {
+  fn to_string(self: bool) -> string {
       bool_to_string(self)
   }
 }
 
 trait Output {
-  fn output(Self) -> Unit;
+  fn output(Self) -> unit;
 }
 
-impl Output for Int {
-  fn output(self: Int) -> Unit {
+impl Output for int {
+  fn output(self: int) -> unit {
       string_println(to_string(self))
   }
 }
 
-impl Output for Bool {
-  fn output(self: Bool) -> Unit {
+impl Output for bool {
+  fn output(self: bool) -> unit {
       string_println(to_string(self))
   }
 }

--- a/crates/compiler/src/tests/cases/018.src.core
+++ b/crates/compiler/src/tests/cases/018.src.core
@@ -1,40 +1,40 @@
-fn impl_Arith_Int_add(self/0: Int, other/1: Int) -> Int {
+fn impl_Arith_int_add(self/0: int, other/1: int) -> int {
   int_add(self/0, other/1)
 }
 
-fn impl_Arith_Int_less(self/2: Int, other/3: Int) -> Bool {
+fn impl_Arith_int_less(self/2: int, other/3: int) -> bool {
   int_less(self/2, other/3)
 }
 
-fn impl_ToString_Int_to_string(self/4: Int) -> String {
+fn impl_ToString_int_to_string(self/4: int) -> string {
   int_to_string(self/4)
 }
 
-fn impl_ToString_Bool_to_string(self/5: Bool) -> String {
+fn impl_ToString_bool_to_string(self/5: bool) -> string {
   bool_to_string(self/5)
 }
 
-fn impl_Output_Int_output(self/6: Int) -> Unit {
-  string_println(impl_ToString_Int_to_string(self/6))
+fn impl_Output_int_output(self/6: int) -> unit {
+  string_println(impl_ToString_int_to_string(self/6))
 }
 
-fn impl_Output_Bool_output(self/7: Bool) -> Unit {
-  string_println(impl_ToString_Bool_to_string(self/7))
+fn impl_Output_bool_output(self/7: bool) -> unit {
+  string_println(impl_ToString_bool_to_string(self/7))
 }
 
 fn id(x/8: T) -> T {
   x/8
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let a/9 = id(1) in
   let b/10 = id(2) in
-  let c/11 = impl_Arith_Int_add(a/9, b/10) in
-  let mtmp0 = impl_Output_Int_output(c/11) in
+  let c/11 = impl_Arith_int_add(a/9, b/10) in
+  let mtmp0 = impl_Output_int_output(c/11) in
   let a/12 = id(3) in
   let b/13 = id(4) in
-  let c/14 = impl_Arith_Int_less(a/12, b/13) in
-  let mtmp1 = impl_Output_Bool_output(c/14) in
+  let c/14 = impl_Arith_int_less(a/12, b/13) in
+  let mtmp1 = impl_Output_bool_output(c/14) in
   let mtmp2 = id("abc") in
   let mtmp3 = id(true) in
   ()

--- a/crates/compiler/src/tests/cases/018.src.cst
+++ b/crates/compiler/src/tests/cases/018.src.cst
@@ -24,7 +24,7 @@ FILE@0..1077
         Arrow@37..39 "->"
         Whitespace@39..40 " "
         TYPE_INT@40..43
-          IntKeyword@40..43 "Int"
+          IntKeyword@40..43 "int"
       Semi@43..44 ";"
       Whitespace@44..49 "\n    "
       TRAIT_METHOD_SIG@49..76
@@ -44,7 +44,7 @@ FILE@0..1077
         Arrow@69..71 "->"
         Whitespace@71..72 " "
         TYPE_BOOL@72..76
-          BoolKeyword@72..76 "Bool"
+          BoolKeyword@72..76 "bool"
       Semi@76..77 ";"
       Whitespace@77..78 "\n"
       RBrace@78..79 "}"
@@ -57,7 +57,7 @@ FILE@0..1077
     ForKeyword@92..95 "for"
     Whitespace@95..96 " "
     TYPE_INT@96..100
-      IntKeyword@96..99 "Int"
+      IntKeyword@96..99 "int"
       Whitespace@99..100 " "
     LBrace@100..101 "{"
     Whitespace@101..106 "\n    "
@@ -72,7 +72,7 @@ FILE@0..1077
           Colon@117..118 ":"
           Whitespace@118..119 " "
           TYPE_INT@119..122
-            IntKeyword@119..122 "Int"
+            IntKeyword@119..122 "int"
           Comma@122..123 ","
           Whitespace@123..124 " "
         PARAM@124..134
@@ -80,13 +80,13 @@ FILE@0..1077
           Colon@129..130 ":"
           Whitespace@130..131 " "
           TYPE_INT@131..134
-            IntKeyword@131..134 "Int"
+            IntKeyword@131..134 "int"
         RParen@134..135 ")"
         Whitespace@135..136 " "
       Arrow@136..138 "->"
       Whitespace@138..139 " "
       TYPE_INT@139..143
-        IntKeyword@139..142 "Int"
+        IntKeyword@139..142 "int"
         Whitespace@142..143 " "
       BLOCK@143..185
         LBrace@143..144 "{"
@@ -119,7 +119,7 @@ FILE@0..1077
           Colon@197..198 ":"
           Whitespace@198..199 " "
           TYPE_INT@199..202
-            IntKeyword@199..202 "Int"
+            IntKeyword@199..202 "int"
           Comma@202..203 ","
           Whitespace@203..204 " "
         PARAM@204..214
@@ -127,13 +127,13 @@ FILE@0..1077
           Colon@209..210 ":"
           Whitespace@210..211 " "
           TYPE_INT@211..214
-            IntKeyword@211..214 "Int"
+            IntKeyword@211..214 "int"
         RParen@214..215 ")"
         Whitespace@215..216 " "
       Arrow@216..218 "->"
       Whitespace@218..219 " "
       TYPE_BOOL@219..224
-        BoolKeyword@219..223 "Bool"
+        BoolKeyword@219..223 "bool"
         Whitespace@223..224 " "
       BLOCK@224..262
         LBrace@224..225 "{"
@@ -178,7 +178,7 @@ FILE@0..1077
         Arrow@305..307 "->"
         Whitespace@307..308 " "
         TYPE_STRING@308..314
-          StringKeyword@308..314 "String"
+          StringKeyword@308..314 "string"
       Semi@314..315 ";"
       Whitespace@315..316 "\n"
       RBrace@316..317 "}"
@@ -191,7 +191,7 @@ FILE@0..1077
     ForKeyword@333..336 "for"
     Whitespace@336..337 " "
     TYPE_INT@337..341
-      IntKeyword@337..340 "Int"
+      IntKeyword@337..340 "int"
       Whitespace@340..341 " "
     LBrace@341..342 "{"
     Whitespace@342..347 "\n    "
@@ -206,13 +206,13 @@ FILE@0..1077
           Colon@364..365 ":"
           Whitespace@365..366 " "
           TYPE_INT@366..369
-            IntKeyword@366..369 "Int"
+            IntKeyword@366..369 "int"
         RParen@369..370 ")"
         Whitespace@370..371 " "
       Arrow@371..373 "->"
       Whitespace@373..374 " "
       TYPE_STRING@374..381
-        StringKeyword@374..380 "String"
+        StringKeyword@374..380 "string"
         Whitespace@380..381 " "
       BLOCK@381..417
         LBrace@381..382 "{"
@@ -239,7 +239,7 @@ FILE@0..1077
     ForKeyword@434..437 "for"
     Whitespace@437..438 " "
     TYPE_BOOL@438..443
-      BoolKeyword@438..442 "Bool"
+      BoolKeyword@438..442 "bool"
       Whitespace@442..443 " "
     LBrace@443..444 "{"
     Whitespace@444..449 "\n    "
@@ -254,13 +254,13 @@ FILE@0..1077
           Colon@466..467 ":"
           Whitespace@467..468 " "
           TYPE_BOOL@468..472
-            BoolKeyword@468..472 "Bool"
+            BoolKeyword@468..472 "bool"
         RParen@472..473 ")"
         Whitespace@473..474 " "
       Arrow@474..476 "->"
       Whitespace@476..477 " "
       TYPE_STRING@477..484
-        StringKeyword@477..483 "String"
+        StringKeyword@477..483 "string"
         Whitespace@483..484 " "
       BLOCK@484..521
         LBrace@484..485 "{"
@@ -300,7 +300,7 @@ FILE@0..1077
         Arrow@559..561 "->"
         Whitespace@561..562 " "
         TYPE_UNIT@562..566
-          UnitKeyword@562..566 "Unit"
+          UnitKeyword@562..566 "unit"
       Semi@566..567 ";"
       Whitespace@567..568 "\n"
       RBrace@568..569 "}"
@@ -313,7 +313,7 @@ FILE@0..1077
     ForKeyword@583..586 "for"
     Whitespace@586..587 " "
     TYPE_INT@587..591
-      IntKeyword@587..590 "Int"
+      IntKeyword@587..590 "int"
       Whitespace@590..591 " "
     LBrace@591..592 "{"
     Whitespace@592..597 "\n    "
@@ -328,13 +328,13 @@ FILE@0..1077
           Colon@611..612 ":"
           Whitespace@612..613 " "
           TYPE_INT@613..616
-            IntKeyword@613..616 "Int"
+            IntKeyword@613..616 "int"
         RParen@616..617 ")"
         Whitespace@617..618 " "
       Arrow@618..620 "->"
       Whitespace@620..621 " "
       TYPE_UNIT@621..626
-        UnitKeyword@621..625 "Unit"
+        UnitKeyword@621..625 "unit"
         Whitespace@625..626 " "
       BLOCK@626..674
         LBrace@626..627 "{"
@@ -368,7 +368,7 @@ FILE@0..1077
     ForKeyword@689..692 "for"
     Whitespace@692..693 " "
     TYPE_BOOL@693..698
-      BoolKeyword@693..697 "Bool"
+      BoolKeyword@693..697 "bool"
       Whitespace@697..698 " "
     LBrace@698..699 "{"
     Whitespace@699..704 "\n    "
@@ -383,13 +383,13 @@ FILE@0..1077
           Colon@718..719 ":"
           Whitespace@719..720 " "
           TYPE_BOOL@720..724
-            BoolKeyword@720..724 "Bool"
+            BoolKeyword@720..724 "bool"
         RParen@724..725 ")"
         Whitespace@725..726 " "
       Arrow@726..728 "->"
       Whitespace@728..729 " "
       TYPE_UNIT@729..734
-        UnitKeyword@729..733 "Unit"
+        UnitKeyword@729..733 "unit"
         Whitespace@733..734 " "
       BLOCK@734..782
         LBrace@734..735 "{"

--- a/crates/compiler/src/tests/cases/018.src.gom
+++ b/crates/compiler/src/tests/cases/018.src.gom
@@ -51,73 +51,73 @@ func missing(s string) struct{} {
     return struct{}{}
 }
 
-func impl_Arith_Int_add(self__0 int, other__1 int) int {
+func impl_Arith_int_add(self__0 int, other__1 int) int {
     var ret6 int
     ret6 = int_add(self__0, other__1)
     return ret6
 }
 
-func impl_Arith_Int_less(self__2 int, other__3 int) bool {
+func impl_Arith_int_less(self__2 int, other__3 int) bool {
     var ret7 bool
     ret7 = int_less(self__2, other__3)
     return ret7
 }
 
-func impl_ToString_Int_to_string(self__4 int) string {
+func impl_ToString_int_to_string(self__4 int) string {
     var ret8 string
     ret8 = int_to_string(self__4)
     return ret8
 }
 
-func impl_ToString_Bool_to_string(self__5 bool) string {
+func impl_ToString_bool_to_string(self__5 bool) string {
     var ret9 string
     ret9 = bool_to_string(self__5)
     return ret9
 }
 
-func impl_Output_Int_output(self__6 int) struct{} {
+func impl_Output_int_output(self__6 int) struct{} {
     var ret10 struct{}
-    var t4 string = impl_ToString_Int_to_string(self__6)
+    var t4 string = impl_ToString_int_to_string(self__6)
     ret10 = string_println(t4)
     return ret10
 }
 
-func impl_Output_Bool_output(self__7 bool) struct{} {
+func impl_Output_bool_output(self__7 bool) struct{} {
     var ret11 struct{}
-    var t5 string = impl_ToString_Bool_to_string(self__7)
+    var t5 string = impl_ToString_bool_to_string(self__7)
     ret11 = string_println(t5)
     return ret11
 }
 
 func main0() struct{} {
     var ret12 struct{}
-    var a__9 int = id__T_Int(1)
-    var b__10 int = id__T_Int(2)
-    var c__11 int = impl_Arith_Int_add(a__9, b__10)
-    impl_Output_Int_output(c__11)
-    var a__12 int = id__T_Int(3)
-    var b__13 int = id__T_Int(4)
-    var c__14 bool = impl_Arith_Int_less(a__12, b__13)
-    impl_Output_Bool_output(c__14)
-    id__T_String("abc")
-    id__T_Bool(true)
+    var a__9 int = id__T_int(1)
+    var b__10 int = id__T_int(2)
+    var c__11 int = impl_Arith_int_add(a__9, b__10)
+    impl_Output_int_output(c__11)
+    var a__12 int = id__T_int(3)
+    var b__13 int = id__T_int(4)
+    var c__14 bool = impl_Arith_int_less(a__12, b__13)
+    impl_Output_bool_output(c__14)
+    id__T_string("abc")
+    id__T_bool(true)
     ret12 = struct{}{}
     return ret12
 }
 
-func id__T_Int(x__8 int) int {
+func id__T_int(x__8 int) int {
     var ret13 int
     ret13 = x__8
     return ret13
 }
 
-func id__T_String(x__8 string) string {
+func id__T_string(x__8 string) string {
     var ret14 string
     ret14 = x__8
     return ret14
 }
 
-func id__T_Bool(x__8 bool) bool {
+func id__T_bool(x__8 bool) bool {
     var ret15 bool
     ret15 = x__8
     return ret15

--- a/crates/compiler/src/tests/cases/018.src.mono
+++ b/crates/compiler/src/tests/cases/018.src.mono
@@ -1,49 +1,49 @@
-fn impl_Arith_Int_add(self/0: Int, other/1: Int) -> Int {
+fn impl_Arith_int_add(self/0: int, other/1: int) -> int {
   int_add(self/0, other/1)
 }
 
-fn impl_Arith_Int_less(self/2: Int, other/3: Int) -> Bool {
+fn impl_Arith_int_less(self/2: int, other/3: int) -> bool {
   int_less(self/2, other/3)
 }
 
-fn impl_ToString_Int_to_string(self/4: Int) -> String {
+fn impl_ToString_int_to_string(self/4: int) -> string {
   int_to_string(self/4)
 }
 
-fn impl_ToString_Bool_to_string(self/5: Bool) -> String {
+fn impl_ToString_bool_to_string(self/5: bool) -> string {
   bool_to_string(self/5)
 }
 
-fn impl_Output_Int_output(self/6: Int) -> Unit {
-  string_println(impl_ToString_Int_to_string(self/6))
+fn impl_Output_int_output(self/6: int) -> unit {
+  string_println(impl_ToString_int_to_string(self/6))
 }
 
-fn impl_Output_Bool_output(self/7: Bool) -> Unit {
-  string_println(impl_ToString_Bool_to_string(self/7))
+fn impl_Output_bool_output(self/7: bool) -> unit {
+  string_println(impl_ToString_bool_to_string(self/7))
 }
 
-fn main() -> Unit {
-  let a/9 = id__T_Int(1) in
-  let b/10 = id__T_Int(2) in
-  let c/11 = impl_Arith_Int_add(a/9, b/10) in
-  let mtmp0 = impl_Output_Int_output(c/11) in
-  let a/12 = id__T_Int(3) in
-  let b/13 = id__T_Int(4) in
-  let c/14 = impl_Arith_Int_less(a/12, b/13) in
-  let mtmp1 = impl_Output_Bool_output(c/14) in
-  let mtmp2 = id__T_String("abc") in
-  let mtmp3 = id__T_Bool(true) in
+fn main() -> unit {
+  let a/9 = id__T_int(1) in
+  let b/10 = id__T_int(2) in
+  let c/11 = impl_Arith_int_add(a/9, b/10) in
+  let mtmp0 = impl_Output_int_output(c/11) in
+  let a/12 = id__T_int(3) in
+  let b/13 = id__T_int(4) in
+  let c/14 = impl_Arith_int_less(a/12, b/13) in
+  let mtmp1 = impl_Output_bool_output(c/14) in
+  let mtmp2 = id__T_string("abc") in
+  let mtmp3 = id__T_bool(true) in
   ()
 }
 
-fn id__T_Int(x/8: Int) -> Int {
+fn id__T_int(x/8: int) -> int {
   x/8
 }
 
-fn id__T_String(x/8: String) -> String {
+fn id__T_string(x/8: string) -> string {
   x/8
 }
 
-fn id__T_Bool(x/8: Bool) -> Bool {
+fn id__T_bool(x/8: bool) -> bool {
   x/8
 }

--- a/crates/compiler/src/tests/cases/018.src.tast
+++ b/crates/compiler/src/tests/cases/018.src.tast
@@ -1,33 +1,33 @@
-impl Arith for Int{
-  fn add(self/0: Int, other/1: Int) -> Int {
-    int_add((self/0 : Int), (other/1 : Int))
+impl Arith for int{
+  fn add(self/0: int, other/1: int) -> int {
+    int_add((self/0 : int), (other/1 : int))
   }
-  fn less(self/2: Int, other/3: Int) -> Bool {
-    int_less((self/2 : Int), (other/3 : Int))
-  }
-}
-
-impl ToString for Int{
-  fn to_string(self/4: Int) -> String {
-    int_to_string((self/4 : Int))
+  fn less(self/2: int, other/3: int) -> bool {
+    int_less((self/2 : int), (other/3 : int))
   }
 }
 
-impl ToString for Bool{
-  fn to_string(self/5: Bool) -> String {
-    bool_to_string((self/5 : Bool))
+impl ToString for int{
+  fn to_string(self/4: int) -> string {
+    int_to_string((self/4 : int))
   }
 }
 
-impl Output for Int{
-  fn output(self/6: Int) -> Unit {
-    string_println(to_string((self/6 : Int)))
+impl ToString for bool{
+  fn to_string(self/5: bool) -> string {
+    bool_to_string((self/5 : bool))
   }
 }
 
-impl Output for Bool{
-  fn output(self/7: Bool) -> Unit {
-    string_println(to_string((self/7 : Bool)))
+impl Output for int{
+  fn output(self/6: int) -> unit {
+    string_println(to_string((self/6 : int)))
+  }
+}
+
+impl Output for bool{
+  fn output(self/7: bool) -> unit {
+    string_println(to_string((self/7 : bool)))
   }
 }
 
@@ -35,16 +35,16 @@ fn id(x/8: T) -> T {
   (x/8 : T)
 }
 
-fn main() -> Unit {
-  let a/9: Int = id(1) in
-  let b/10: Int = id(2) in
-  let c/11: Int = add((a/9 : Int), (b/10 : Int)) in
-  let _ : Unit = output((c/11 : Int)) in
-  let a/12: Int = id(3) in
-  let b/13: Int = id(4) in
-  let c/14: Bool = less((a/12 : Int), (b/13 : Int)) in
-  let _ : Unit = output((c/14 : Bool)) in
-  let _ : String = id("abc") in
-  let _ : Bool = id(true) in
+fn main() -> unit {
+  let a/9: int = id(1) in
+  let b/10: int = id(2) in
+  let c/11: int = add((a/9 : int), (b/10 : int)) in
+  let _ : unit = output((c/11 : int)) in
+  let a/12: int = id(3) in
+  let b/13: int = id(4) in
+  let c/14: bool = less((a/12 : int), (b/13 : int)) in
+  let _ : unit = output((c/14 : bool)) in
+  let _ : string = id("abc") in
+  let _ : bool = id(true) in
   ()
 }

--- a/crates/compiler/src/tests/cases/019.src
+++ b/crates/compiler/src/tests/cases/019.src
@@ -1,21 +1,21 @@
 struct Point {
-    x: Int,
-    y: Int,
+    x: int,
+    y: int,
 }
 
 struct Wrapper[T] {
     value: T,
 }
 
-fn takes_point(p: Point) -> Int {
+fn takes_point(p: Point) -> int {
     0
 }
 
-fn id_wrapper_int(value: Wrapper[Int]) -> Wrapper[Int] {
+fn id_wrapper_int(value: Wrapper[int]) -> Wrapper[int] {
     value
 }
 
-fn takes_wrapper_unit(value: Wrapper[Unit]) -> Unit {
+fn takes_wrapper_unit(value: Wrapper[unit]) -> unit {
     ()
 }
 

--- a/crates/compiler/src/tests/cases/019.src.anf
+++ b/crates/compiler/src/tests/cases/019.src.anf
@@ -1,16 +1,16 @@
-fn takes_point(p/0: Point) -> Int {
+fn takes_point(p/0: Point) -> int {
   0
 }
 
-fn id_wrapper_int(value/1: Wrapper__Int) -> Wrapper__Int {
+fn id_wrapper_int(value/1: Wrapper__int) -> Wrapper__int {
   value/1
 }
 
-fn takes_wrapper_unit(value/2: Wrapper__Unit) -> Unit {
+fn takes_wrapper_unit(value/2: Wrapper__unit) -> unit {
   ()
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_println("structs!") in
   ()
 }

--- a/crates/compiler/src/tests/cases/019.src.ast
+++ b/crates/compiler/src/tests/cases/019.src.ast
@@ -1,21 +1,21 @@
 struct Point {
-    x: Int,
-    y: Int,
+    x: int,
+    y: int,
 }
 
 struct Wrapper {
     value: T,
 }
 
-fn takes_point(p: Point) -> Int {
+fn takes_point(p: Point) -> int {
     0
 }
 
-fn id_wrapper_int(value: Wrapper[Int]) -> Wrapper[Int] {
+fn id_wrapper_int(value: Wrapper[int]) -> Wrapper[int] {
     value
 }
 
-fn takes_wrapper_unit(value: Wrapper[Unit]) -> Unit {
+fn takes_wrapper_unit(value: Wrapper[unit]) -> unit {
     ()
 }
 

--- a/crates/compiler/src/tests/cases/019.src.core
+++ b/crates/compiler/src/tests/cases/019.src.core
@@ -1,16 +1,16 @@
-fn takes_point(p/0: Point) -> Int {
+fn takes_point(p/0: Point) -> int {
   0
 }
 
-fn id_wrapper_int(value/1: Wrapper[Int]) -> Wrapper[Int] {
+fn id_wrapper_int(value/1: Wrapper[int]) -> Wrapper[int] {
   value/1
 }
 
-fn takes_wrapper_unit(value/2: Wrapper[Unit]) -> Unit {
+fn takes_wrapper_unit(value/2: Wrapper[unit]) -> unit {
   ()
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_println("structs!") in
   ()
 }

--- a/crates/compiler/src/tests/cases/019.src.cst
+++ b/crates/compiler/src/tests/cases/019.src.cst
@@ -12,7 +12,7 @@ FILE@0..319
         Colon@20..21 ":"
         Whitespace@21..22 " "
         TYPE_INT@22..25
-          IntKeyword@22..25 "Int"
+          IntKeyword@22..25 "int"
       Comma@25..26 ","
       Whitespace@26..31 "\n    "
       STRUCT_FIELD@31..37
@@ -20,7 +20,7 @@ FILE@0..319
         Colon@32..33 ":"
         Whitespace@33..34 " "
         TYPE_INT@34..37
-          IntKeyword@34..37 "Int"
+          IntKeyword@34..37 "int"
       Comma@37..38 ","
       Whitespace@38..39 "\n"
       RBrace@39..40 "}"
@@ -65,7 +65,7 @@ FILE@0..319
     Arrow@104..106 "->"
     Whitespace@106..107 " "
     TYPE_INT@107..111
-      IntKeyword@107..110 "Int"
+      IntKeyword@107..110 "int"
       Whitespace@110..111 " "
     BLOCK@111..122
       LBrace@111..112 "{"
@@ -90,7 +90,7 @@ FILE@0..319
           TYPE_PARAM_LIST@154..159
             LBracket@154..155 "["
             TYPE_INT@155..158
-              IntKeyword@155..158 "Int"
+              IntKeyword@155..158 "int"
             RBracket@158..159 "]"
       RParen@159..160 ")"
       Whitespace@160..161 " "
@@ -101,7 +101,7 @@ FILE@0..319
       TYPE_PARAM_LIST@171..177
         LBracket@171..172 "["
         TYPE_INT@172..175
-          IntKeyword@172..175 "Int"
+          IntKeyword@172..175 "int"
         RBracket@175..176 "]"
         Whitespace@176..177 " "
     BLOCK@177..192
@@ -127,14 +127,14 @@ FILE@0..319
           TYPE_PARAM_LIST@228..234
             LBracket@228..229 "["
             TYPE_UNIT@229..233
-              UnitKeyword@229..233 "Unit"
+              UnitKeyword@229..233 "unit"
             RBracket@233..234 "]"
       RParen@234..235 ")"
       Whitespace@235..236 " "
     Arrow@236..238 "->"
     Whitespace@238..239 " "
     TYPE_UNIT@239..244
-      UnitKeyword@239..243 "Unit"
+      UnitKeyword@239..243 "unit"
       Whitespace@243..244 " "
     BLOCK@244..256
       LBrace@244..245 "{"

--- a/crates/compiler/src/tests/cases/019.src.gom
+++ b/crates/compiler/src/tests/cases/019.src.gom
@@ -56,11 +56,11 @@ type Point struct {
     y int
 }
 
-type Wrapper__Int struct {
+type Wrapper__int struct {
     value int
 }
 
-type Wrapper__Unit struct {
+type Wrapper__unit struct {
     value struct{}
 }
 
@@ -70,13 +70,13 @@ func takes_point(p__0 Point) int {
     return ret1
 }
 
-func id_wrapper_int(value__1 Wrapper__Int) Wrapper__Int {
-    var ret2 Wrapper__Int
+func id_wrapper_int(value__1 Wrapper__int) Wrapper__int {
+    var ret2 Wrapper__int
     ret2 = value__1
     return ret2
 }
 
-func takes_wrapper_unit(value__2 Wrapper__Unit) struct{} {
+func takes_wrapper_unit(value__2 Wrapper__unit) struct{} {
     var ret3 struct{}
     ret3 = struct{}{}
     return ret3

--- a/crates/compiler/src/tests/cases/019.src.mono
+++ b/crates/compiler/src/tests/cases/019.src.mono
@@ -1,16 +1,16 @@
-fn takes_point(p/0: Point) -> Int {
+fn takes_point(p/0: Point) -> int {
   0
 }
 
-fn id_wrapper_int(value/1: Wrapper__Int) -> Wrapper__Int {
+fn id_wrapper_int(value/1: Wrapper__int) -> Wrapper__int {
   value/1
 }
 
-fn takes_wrapper_unit(value/2: Wrapper__Unit) -> Unit {
+fn takes_wrapper_unit(value/2: Wrapper__unit) -> unit {
   ()
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_println("structs!") in
   ()
 }

--- a/crates/compiler/src/tests/cases/019.src.tast
+++ b/crates/compiler/src/tests/cases/019.src.tast
@@ -1,16 +1,16 @@
-fn takes_point(p/0: Point) -> Int {
+fn takes_point(p/0: Point) -> int {
   0
 }
 
-fn id_wrapper_int(value/1: Wrapper[Int]) -> Wrapper[Int] {
-  (value/1 : Wrapper[Int])
+fn id_wrapper_int(value/1: Wrapper[int]) -> Wrapper[int] {
+  (value/1 : Wrapper[int])
 }
 
-fn takes_wrapper_unit(value/2: Wrapper[Unit]) -> Unit {
+fn takes_wrapper_unit(value/2: Wrapper[unit]) -> unit {
   ()
 }
 
-fn main() -> Unit {
-  let _ : Unit = string_println("structs!") in
+fn main() -> unit {
+  let _ : unit = string_println("structs!") in
   ()
 }

--- a/crates/compiler/src/tests/cases/020.src
+++ b/crates/compiler/src/tests/cases/020.src
@@ -1,6 +1,6 @@
 struct Point {
-    x: Int,
-    y: Int,
+    x: int,
+    y: int,
 }
 
 struct Wrapper[T] {
@@ -13,7 +13,7 @@ enum Shape[T] {
     Origin,
 }
 
-fn bounce_int(shape: Shape[Int]) -> Shape[Int] {
+fn bounce_int(shape: Shape[int]) -> Shape[int] {
     match shape {
         Dot(point) => Dot(point),
         Wrapped(inner) => Wrapped(inner),
@@ -21,18 +21,18 @@ fn bounce_int(shape: Shape[Int]) -> Shape[Int] {
     }
 }
 
-fn wrap_unit(value: Wrapper[Unit]) -> Shape[Unit] {
+fn wrap_unit(value: Wrapper[unit]) -> Shape[unit] {
     Wrapped(value)
 }
 
-fn pick(flag: Bool, point: Point, wrapper: Wrapper[Int]) -> Shape[Int] {
+fn pick(flag: bool, point: Point, wrapper: Wrapper[int]) -> Shape[int] {
     match flag {
         true => Dot(point),
         false => Wrapped(wrapper),
     }
 }
 
-fn describe[T](shape: Shape[T]) -> Int {
+fn describe[T](shape: Shape[T]) -> int {
     match shape {
         Dot(_) => 1,
         Wrapped(_) => 2,
@@ -40,7 +40,7 @@ fn describe[T](shape: Shape[T]) -> Int {
     }
 }
 
-fn point_to_string(point: Point) -> String {
+fn point_to_string(point: Point) -> string {
     let Point(x, y) = point in
     let with_x = string_add("Point { x: ", int_to_string(x)) in
     let with_y_label = string_add(with_x, ", y: ") in
@@ -48,19 +48,19 @@ fn point_to_string(point: Point) -> String {
     string_add(with_y, " }")
 }
 
-fn wrapper_int_to_string(wrapper: Wrapper[Int]) -> String {
+fn wrapper_int_to_string(wrapper: Wrapper[int]) -> string {
     let Wrapper(value) = wrapper in
-    let prefix = string_add("Wrapper[Int] { value: ", int_to_string(value)) in
+    let prefix = string_add("Wrapper[int] { value: ", int_to_string(value)) in
     string_add(prefix, " }")
 }
 
-fn wrapper_unit_to_string(wrapper: Wrapper[Unit]) -> String {
+fn wrapper_unit_to_string(wrapper: Wrapper[unit]) -> string {
     let Wrapper(value) = wrapper in
-    let prefix = string_add("Wrapper[Unit] { value: ", unit_to_string(value)) in
+    let prefix = string_add("Wrapper[unit] { value: ", unit_to_string(value)) in
     string_add(prefix, " }")
 }
 
-fn shape_int_to_string(shape: Shape[Int]) -> String {
+fn shape_int_to_string(shape: Shape[int]) -> string {
     match shape {
         Dot(point) =>
             let prefix = string_add("Shape::Dot(", point_to_string(point)) in
@@ -72,7 +72,7 @@ fn shape_int_to_string(shape: Shape[Int]) -> String {
     }
 }
 
-fn shape_unit_to_string(shape: Shape[Unit]) -> String {
+fn shape_unit_to_string(shape: Shape[unit]) -> string {
     match shape {
         Dot(point) =>
             let prefix = string_add("Shape::Dot(", point_to_string(point)) in

--- a/crates/compiler/src/tests/cases/020.src.anf
+++ b/crates/compiler/src/tests/cases/020.src.anf
@@ -1,14 +1,14 @@
-fn bounce_int(shape/0: Shape__Int) -> Shape__Int {
+fn bounce_int(shape/0: Shape__int) -> Shape__int {
   match shape/0 {
     Tag_0 => {
-      let x0 = Shape__Int::Dot._0(shape/0) in
+      let x0 = Shape__int::Dot._0(shape/0) in
       let point/1 = x0 in
-      Shape__Int::Dot(point/1)
+      Shape__int::Dot(point/1)
     },
     Tag_1 => {
-      let x1 = Shape__Int::Wrapped._0(shape/0) in
+      let x1 = Shape__int::Wrapped._0(shape/0) in
       let inner/2 = x1 in
-      Shape__Int::Wrapped(inner/2)
+      Shape__int::Wrapped(inner/2)
     },
     Tag_2 => {
       Tag_2
@@ -16,22 +16,22 @@ fn bounce_int(shape/0: Shape__Int) -> Shape__Int {
   }
 }
 
-fn wrap_unit(value/3: Wrapper__Unit) -> Shape__Unit {
-  Shape__Unit::Wrapped(value/3)
+fn wrap_unit(value/3: Wrapper__unit) -> Shape__unit {
+  Shape__unit::Wrapped(value/3)
 }
 
-fn pick(flag/4: Bool, point/5: Point, wrapper/6: Wrapper__Int) -> Shape__Int {
+fn pick(flag/4: bool, point/5: Point, wrapper/6: Wrapper__int) -> Shape__int {
   match flag/4 {
     true => {
-      Shape__Int::Dot(point/5)
+      Shape__int::Dot(point/5)
     },
     false => {
-      Shape__Int::Wrapped(wrapper/6)
+      Shape__int::Wrapped(wrapper/6)
     },
   }
 }
 
-fn point_to_string(point/8: Point) -> String {
+fn point_to_string(point/8: Point) -> string {
   let mtmp4 = point/8 in
   let x5 = Point.x(mtmp4) in
   let x6 = Point.y(mtmp4) in
@@ -45,35 +45,35 @@ fn point_to_string(point/8: Point) -> String {
   string_add(with_y/13, " }")
 }
 
-fn wrapper_int_to_string(wrapper/14: Wrapper__Int) -> String {
+fn wrapper_int_to_string(wrapper/14: Wrapper__int) -> string {
   let mtmp7 = wrapper/14 in
-  let x8 = Wrapper__Int.value(mtmp7) in
+  let x8 = Wrapper__int.value(mtmp7) in
   let value/15 = x8 in
   let t27 = int_to_string(value/15) in
-  let prefix/16 = string_add("Wrapper[Int] { value: ", t27) in
+  let prefix/16 = string_add("Wrapper[int] { value: ", t27) in
   string_add(prefix/16, " }")
 }
 
-fn wrapper_unit_to_string(wrapper/17: Wrapper__Unit) -> String {
+fn wrapper_unit_to_string(wrapper/17: Wrapper__unit) -> string {
   let mtmp9 = wrapper/17 in
-  let x10 = Wrapper__Unit.value(mtmp9) in
+  let x10 = Wrapper__unit.value(mtmp9) in
   let value/18 = x10 in
   let t28 = unit_to_string(value/18) in
-  let prefix/19 = string_add("Wrapper[Unit] { value: ", t28) in
+  let prefix/19 = string_add("Wrapper[unit] { value: ", t28) in
   string_add(prefix/19, " }")
 }
 
-fn shape_int_to_string(shape/20: Shape__Int) -> String {
+fn shape_int_to_string(shape/20: Shape__int) -> string {
   match shape/20 {
     Tag_0 => {
-      let x11 = Shape__Int::Dot._0(shape/20) in
+      let x11 = Shape__int::Dot._0(shape/20) in
       let point/21 = x11 in
       let t29 = point_to_string(point/21) in
       let prefix/22 = string_add("Shape::Dot(", t29) in
       string_add(prefix/22, ")")
     },
     Tag_1 => {
-      let x12 = Shape__Int::Wrapped._0(shape/20) in
+      let x12 = Shape__int::Wrapped._0(shape/20) in
       let wrapper/23 = x12 in
       let t30 = wrapper_int_to_string(wrapper/23) in
       let prefix/24 = string_add("Shape::Wrapped(", t30) in
@@ -85,17 +85,17 @@ fn shape_int_to_string(shape/20: Shape__Int) -> String {
   }
 }
 
-fn shape_unit_to_string(shape/25: Shape__Unit) -> String {
+fn shape_unit_to_string(shape/25: Shape__unit) -> string {
   match shape/25 {
     Tag_0 => {
-      let x13 = Shape__Unit::Dot._0(shape/25) in
+      let x13 = Shape__unit::Dot._0(shape/25) in
       let point/26 = x13 in
       let t31 = point_to_string(point/26) in
       let prefix/27 = string_add("Shape::Dot(", t31) in
       string_add(prefix/27, ")")
     },
     Tag_1 => {
-      let x14 = Shape__Unit::Wrapped._0(shape/25) in
+      let x14 = Shape__unit::Wrapped._0(shape/25) in
       let wrapper/28 = x14 in
       let t32 = wrapper_unit_to_string(wrapper/28) in
       let prefix/29 = string_add("Shape::Wrapped(", t32) in
@@ -107,34 +107,34 @@ fn shape_unit_to_string(shape/25: Shape__Unit) -> String {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t34 = Point(3, 4) in
   let t33 = point_to_string(t34) in
   let mtmp15 = string_println(t33) in
-  let t36 = Wrapper__Int(7) in
+  let t36 = Wrapper__int(7) in
   let t35 = wrapper_int_to_string(t36) in
   let mtmp16 = string_println(t35) in
-  let t38 = Wrapper__Unit(()) in
+  let t38 = Wrapper__unit(()) in
   let t37 = wrapper_unit_to_string(t38) in
   let mtmp17 = string_println(t37) in
   let t39 = Tag_2 in
   let bounced_origin/30 = bounce_int(t39) in
   let t42 = Point(3, 4) in
-  let t41 = Shape__Int::Dot(t42) in
+  let t41 = Shape__int::Dot(t42) in
   let t40 = shape_int_to_string(t41) in
   let mtmp18 = string_println(t40) in
-  let t45 = Wrapper__Int(7) in
-  let t44 = Shape__Int::Wrapped(t45) in
+  let t45 = Wrapper__int(7) in
+  let t44 = Shape__int::Wrapped(t45) in
   let t43 = shape_int_to_string(t44) in
   let mtmp19 = string_println(t43) in
   let t46 = shape_int_to_string(bounced_origin/30) in
   let mtmp20 = string_println(t46) in
   let t49 = Point(3, 4) in
-  let t48 = Shape__Unit::Dot(t49) in
+  let t48 = Shape__unit::Dot(t49) in
   let t47 = shape_unit_to_string(t48) in
   let mtmp21 = string_println(t47) in
-  let t52 = Wrapper__Unit(()) in
-  let t51 = Shape__Unit::Wrapped(t52) in
+  let t52 = Wrapper__unit(()) in
+  let t51 = Shape__unit::Wrapped(t52) in
   let t50 = shape_unit_to_string(t51) in
   let mtmp22 = string_println(t50) in
   let t54 = Tag_2 in
@@ -142,18 +142,18 @@ fn main() -> Unit {
   let mtmp23 = string_println(t53) in
   let t56 = Tag_2 in
   let t55 = bounce_int(t56) in
-  let mtmp24 = describe__T_Int(t55) in
+  let mtmp24 = describe__T_int(t55) in
   string_println("struct enums!")
 }
 
-fn describe__T_Int(shape/7: Shape__Int) -> Int {
+fn describe__T_int(shape/7: Shape__int) -> int {
   match shape/7 {
     Tag_0 => {
-      let x2 = Shape__Int::Dot._0(shape/7) in
+      let x2 = Shape__int::Dot._0(shape/7) in
       1
     },
     Tag_1 => {
-      let x3 = Shape__Int::Wrapped._0(shape/7) in
+      let x3 = Shape__int::Wrapped._0(shape/7) in
       2
     },
     Tag_2 => {

--- a/crates/compiler/src/tests/cases/020.src.ast
+++ b/crates/compiler/src/tests/cases/020.src.ast
@@ -1,6 +1,6 @@
 struct Point {
-    x: Int,
-    y: Int,
+    x: int,
+    y: int,
 }
 
 struct Wrapper {
@@ -13,7 +13,7 @@ enum Shape {
     Origin
 }
 
-fn bounce_int(shape: Shape[Int]) -> Shape[Int] {
+fn bounce_int(shape: Shape[int]) -> Shape[int] {
     match shape {
         Dot(point) => Dot(point),
         Wrapped(inner) => Wrapped(inner),
@@ -21,18 +21,18 @@ fn bounce_int(shape: Shape[Int]) -> Shape[Int] {
     }
 }
 
-fn wrap_unit(value: Wrapper[Unit]) -> Shape[Unit] {
+fn wrap_unit(value: Wrapper[unit]) -> Shape[unit] {
     Wrapped(value)
 }
 
-fn pick(flag: Bool, point: Point, wrapper: Wrapper[Int]) -> Shape[Int] {
+fn pick(flag: bool, point: Point, wrapper: Wrapper[int]) -> Shape[int] {
     match flag {
         true => Dot(point),
         false => Wrapped(wrapper),
     }
 }
 
-fn describe(shape: Shape[T]) -> Int {
+fn describe(shape: Shape[T]) -> int {
     match shape {
         Dot(_) => 1,
         Wrapped(_) => 2,
@@ -40,7 +40,7 @@ fn describe(shape: Shape[T]) -> Int {
     }
 }
 
-fn point_to_string(point: Point) -> String {
+fn point_to_string(point: Point) -> string {
     let Point(x, y) = point in
     let with_x = string_add("Point { x: ", int_to_string(x)) in
     let with_y_label = string_add(with_x, ", y: ") in
@@ -48,19 +48,19 @@ fn point_to_string(point: Point) -> String {
     string_add(with_y, " }")
 }
 
-fn wrapper_int_to_string(wrapper: Wrapper[Int]) -> String {
+fn wrapper_int_to_string(wrapper: Wrapper[int]) -> string {
     let Wrapper(value) = wrapper in
-    let prefix = string_add("Wrapper[Int] { value: ", int_to_string(value)) in
+    let prefix = string_add("Wrapper[int] { value: ", int_to_string(value)) in
     string_add(prefix, " }")
 }
 
-fn wrapper_unit_to_string(wrapper: Wrapper[Unit]) -> String {
+fn wrapper_unit_to_string(wrapper: Wrapper[unit]) -> string {
     let Wrapper(value) = wrapper in
-    let prefix = string_add("Wrapper[Unit] { value: ", unit_to_string(value)) in
+    let prefix = string_add("Wrapper[unit] { value: ", unit_to_string(value)) in
     string_add(prefix, " }")
 }
 
-fn shape_int_to_string(shape: Shape[Int]) -> String {
+fn shape_int_to_string(shape: Shape[int]) -> string {
     match shape {
         Dot(point) => let prefix = string_add("Shape::Dot(", point_to_string(point)) in
           string_add(prefix, ")"),
@@ -70,7 +70,7 @@ fn shape_int_to_string(shape: Shape[Int]) -> String {
     }
 }
 
-fn shape_unit_to_string(shape: Shape[Unit]) -> String {
+fn shape_unit_to_string(shape: Shape[unit]) -> string {
     match shape {
         Dot(point) => let prefix = string_add("Shape::Dot(", point_to_string(point)) in
           string_add(prefix, ")"),

--- a/crates/compiler/src/tests/cases/020.src.core
+++ b/crates/compiler/src/tests/cases/020.src.core
@@ -1,4 +1,4 @@
-fn bounce_int(shape/0: Shape[Int]) -> Shape[Int] {
+fn bounce_int(shape/0: Shape[int]) -> Shape[int] {
   match shape/0 {
     Shape::Dot(x0) => {
       let x0 = Shape::Dot._0(shape/0) in
@@ -16,11 +16,11 @@ fn bounce_int(shape/0: Shape[Int]) -> Shape[Int] {
   }
 }
 
-fn wrap_unit(value/3: Wrapper[Unit]) -> Shape[Unit] {
+fn wrap_unit(value/3: Wrapper[unit]) -> Shape[unit] {
   Shape::Wrapped(value/3)
 }
 
-fn pick(flag/4: Bool, point/5: Point, wrapper/6: Wrapper[Int]) -> Shape[Int] {
+fn pick(flag/4: bool, point/5: Point, wrapper/6: Wrapper[int]) -> Shape[int] {
   match flag/4 {
     true => {
       Shape::Dot(point/5)
@@ -31,7 +31,7 @@ fn pick(flag/4: Bool, point/5: Point, wrapper/6: Wrapper[Int]) -> Shape[Int] {
   }
 }
 
-fn describe(shape/7: Shape[T]) -> Int {
+fn describe(shape/7: Shape[T]) -> int {
   match shape/7 {
     Shape::Dot(x2) => {
       let x2 = Shape::Dot._0(shape/7) in
@@ -47,7 +47,7 @@ fn describe(shape/7: Shape[T]) -> Int {
   }
 }
 
-fn point_to_string(point/8: Point) -> String {
+fn point_to_string(point/8: Point) -> string {
   let mtmp4 = point/8 in
   let x5 = Point.x(mtmp4) in
   let x6 = Point.y(mtmp4) in
@@ -59,23 +59,23 @@ fn point_to_string(point/8: Point) -> String {
   string_add(with_y/13, " }")
 }
 
-fn wrapper_int_to_string(wrapper/14: Wrapper[Int]) -> String {
+fn wrapper_int_to_string(wrapper/14: Wrapper[int]) -> string {
   let mtmp7 = wrapper/14 in
   let x8 = Wrapper.value(mtmp7) in
   let value/15 = x8 in
-  let prefix/16 = string_add("Wrapper[Int] { value: ", int_to_string(value/15)) in
+  let prefix/16 = string_add("Wrapper[int] { value: ", int_to_string(value/15)) in
   string_add(prefix/16, " }")
 }
 
-fn wrapper_unit_to_string(wrapper/17: Wrapper[Unit]) -> String {
+fn wrapper_unit_to_string(wrapper/17: Wrapper[unit]) -> string {
   let mtmp9 = wrapper/17 in
   let x10 = Wrapper.value(mtmp9) in
   let value/18 = x10 in
-  let prefix/19 = string_add("Wrapper[Unit] { value: ", unit_to_string(value/18)) in
+  let prefix/19 = string_add("Wrapper[unit] { value: ", unit_to_string(value/18)) in
   string_add(prefix/19, " }")
 }
 
-fn shape_int_to_string(shape/20: Shape[Int]) -> String {
+fn shape_int_to_string(shape/20: Shape[int]) -> string {
   match shape/20 {
     Shape::Dot(x11) => {
       let x11 = Shape::Dot._0(shape/20) in
@@ -95,7 +95,7 @@ fn shape_int_to_string(shape/20: Shape[Int]) -> String {
   }
 }
 
-fn shape_unit_to_string(shape/25: Shape[Unit]) -> String {
+fn shape_unit_to_string(shape/25: Shape[unit]) -> string {
   match shape/25 {
     Shape::Dot(x13) => {
       let x13 = Shape::Dot._0(shape/25) in
@@ -115,7 +115,7 @@ fn shape_unit_to_string(shape/25: Shape[Unit]) -> String {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp15 = string_println(point_to_string(Point(3, 4))) in
   let mtmp16 = string_println(wrapper_int_to_string(Wrapper(7))) in
   let mtmp17 = string_println(wrapper_unit_to_string(Wrapper(()))) in

--- a/crates/compiler/src/tests/cases/020.src.cst
+++ b/crates/compiler/src/tests/cases/020.src.cst
@@ -12,7 +12,7 @@ FILE@0..2973
         Colon@20..21 ":"
         Whitespace@21..22 " "
         TYPE_INT@22..25
-          IntKeyword@22..25 "Int"
+          IntKeyword@22..25 "int"
       Comma@25..26 ","
       Whitespace@26..31 "\n    "
       STRUCT_FIELD@31..37
@@ -20,7 +20,7 @@ FILE@0..2973
         Colon@32..33 ":"
         Whitespace@33..34 " "
         TYPE_INT@34..37
-          IntKeyword@34..37 "Int"
+          IntKeyword@34..37 "int"
       Comma@37..38 ","
       Whitespace@38..39 "\n"
       RBrace@39..40 "}"
@@ -105,7 +105,7 @@ FILE@0..2973
           TYPE_PARAM_LIST@177..182
             LBracket@177..178 "["
             TYPE_INT@178..181
-              IntKeyword@178..181 "Int"
+              IntKeyword@178..181 "int"
             RBracket@181..182 "]"
       RParen@182..183 ")"
       Whitespace@183..184 " "
@@ -116,7 +116,7 @@ FILE@0..2973
       TYPE_PARAM_LIST@192..198
         LBracket@192..193 "["
         TYPE_INT@193..196
-          IntKeyword@193..196 "Int"
+          IntKeyword@193..196 "int"
         RBracket@196..197 "]"
         Whitespace@197..198 " "
     BLOCK@198..329
@@ -202,7 +202,7 @@ FILE@0..2973
           TYPE_PARAM_LIST@356..362
             LBracket@356..357 "["
             TYPE_UNIT@357..361
-              UnitKeyword@357..361 "Unit"
+              UnitKeyword@357..361 "unit"
             RBracket@361..362 "]"
       RParen@362..363 ")"
       Whitespace@363..364 " "
@@ -213,7 +213,7 @@ FILE@0..2973
       TYPE_PARAM_LIST@372..379
         LBracket@372..373 "["
         TYPE_UNIT@373..377
-          UnitKeyword@373..377 "Unit"
+          UnitKeyword@373..377 "unit"
         RBracket@377..378 "]"
         Whitespace@378..379 " "
     BLOCK@379..403
@@ -242,7 +242,7 @@ FILE@0..2973
         Colon@415..416 ":"
         Whitespace@416..417 " "
         TYPE_BOOL@417..421
-          BoolKeyword@417..421 "Bool"
+          BoolKeyword@417..421 "bool"
         Comma@421..422 ","
         Whitespace@422..423 " "
       PARAM@423..437
@@ -262,7 +262,7 @@ FILE@0..2973
           TYPE_PARAM_LIST@453..458
             LBracket@453..454 "["
             TYPE_INT@454..457
-              IntKeyword@454..457 "Int"
+              IntKeyword@454..457 "int"
             RBracket@457..458 "]"
       RParen@458..459 ")"
       Whitespace@459..460 " "
@@ -273,7 +273,7 @@ FILE@0..2973
       TYPE_PARAM_LIST@468..474
         LBracket@468..469 "["
         TYPE_INT@469..472
-          IntKeyword@469..472 "Int"
+          IntKeyword@469..472 "int"
         RBracket@472..473 "]"
         Whitespace@473..474 " "
     BLOCK@474..565
@@ -353,7 +353,7 @@ FILE@0..2973
     Arrow@597..599 "->"
     Whitespace@599..600 " "
     TYPE_INT@600..604
-      IntKeyword@600..603 "Int"
+      IntKeyword@600..603 "int"
       Whitespace@603..604 " "
     BLOCK@604..700
       LBrace@604..605 "{"
@@ -426,7 +426,7 @@ FILE@0..2973
     Arrow@733..735 "->"
     Whitespace@735..736 " "
     TYPE_STRING@736..743
-      StringKeyword@736..742 "String"
+      StringKeyword@736..742 "string"
       Whitespace@742..743 " "
     BLOCK@743..989
       LBrace@743..744 "{"
@@ -581,14 +581,14 @@ FILE@0..2973
           TYPE_PARAM_LIST@1030..1035
             LBracket@1030..1031 "["
             TYPE_INT@1031..1034
-              IntKeyword@1031..1034 "Int"
+              IntKeyword@1031..1034 "int"
             RBracket@1034..1035 "]"
       RParen@1035..1036 ")"
       Whitespace@1036..1037 " "
     Arrow@1037..1039 "->"
     Whitespace@1039..1040 " "
     TYPE_STRING@1040..1047
-      StringKeyword@1040..1046 "String"
+      StringKeyword@1040..1046 "string"
       Whitespace@1046..1047 " "
     BLOCK@1047..1196
       LBrace@1047..1048 "{"
@@ -628,7 +628,7 @@ FILE@0..2973
                   LParen@1112..1113 "("
                   ARG@1113..1139
                     EXPR_STR@1113..1137
-                      Str@1113..1137 "\"Wrapper[Int] { value: \""
+                      Str@1113..1137 "\"Wrapper[int] { value: \""
                     Comma@1137..1138 ","
                     Whitespace@1138..1139 " "
                   ARG@1139..1159
@@ -678,14 +678,14 @@ FILE@0..2973
           TYPE_PARAM_LIST@1238..1244
             LBracket@1238..1239 "["
             TYPE_UNIT@1239..1243
-              UnitKeyword@1239..1243 "Unit"
+              UnitKeyword@1239..1243 "unit"
             RBracket@1243..1244 "]"
       RParen@1244..1245 ")"
       Whitespace@1245..1246 " "
     Arrow@1246..1248 "->"
     Whitespace@1248..1249 " "
     TYPE_STRING@1249..1256
-      StringKeyword@1249..1255 "String"
+      StringKeyword@1249..1255 "string"
       Whitespace@1255..1256 " "
     BLOCK@1256..1407
       LBrace@1256..1257 "{"
@@ -725,7 +725,7 @@ FILE@0..2973
                   LParen@1321..1322 "("
                   ARG@1322..1349
                     EXPR_STR@1322..1347
-                      Str@1322..1347 "\"Wrapper[Unit] { valu ..."
+                      Str@1322..1347 "\"Wrapper[unit] { valu ..."
                     Comma@1347..1348 ","
                     Whitespace@1348..1349 " "
                   ARG@1349..1370
@@ -775,14 +775,14 @@ FILE@0..2973
           TYPE_PARAM_LIST@1442..1447
             LBracket@1442..1443 "["
             TYPE_INT@1443..1446
-              IntKeyword@1443..1446 "Int"
+              IntKeyword@1443..1446 "int"
             RBracket@1446..1447 "]"
       RParen@1447..1448 ")"
       Whitespace@1448..1449 " "
     Arrow@1449..1451 "->"
     Whitespace@1451..1452 " "
     TYPE_STRING@1452..1459
-      StringKeyword@1452..1458 "String"
+      StringKeyword@1452..1458 "string"
       Whitespace@1458..1459 " "
     BLOCK@1459..1815
       LBrace@1459..1460 "{"
@@ -945,14 +945,14 @@ FILE@0..2973
           TYPE_PARAM_LIST@1851..1857
             LBracket@1851..1852 "["
             TYPE_UNIT@1852..1856
-              UnitKeyword@1852..1856 "Unit"
+              UnitKeyword@1852..1856 "unit"
             RBracket@1856..1857 "]"
       RParen@1857..1858 ")"
       Whitespace@1858..1859 " "
     Arrow@1859..1861 "->"
     Whitespace@1861..1862 " "
     TYPE_STRING@1862..1869
-      StringKeyword@1862..1868 "String"
+      StringKeyword@1862..1868 "string"
       Whitespace@1868..1869 " "
     BLOCK@1869..2226
       LBrace@1869..1870 "{"

--- a/crates/compiler/src/tests/cases/020.src.gom
+++ b/crates/compiler/src/tests/cases/020.src.gom
@@ -56,92 +56,92 @@ type Point struct {
     y int
 }
 
-type Wrapper__Int struct {
+type Wrapper__int struct {
     value int
 }
 
-type Wrapper__Unit struct {
+type Wrapper__unit struct {
     value struct{}
 }
 
-type Shape__Int interface {
-    isShape__Int()
+type Shape__int interface {
+    isShape__int()
 }
 
-type Shape__Int_Dot struct {
+type Shape__int_Dot struct {
     _0 Point
 }
 
-func (_ Shape__Int_Dot) isShape__Int() {}
+func (_ Shape__int_Dot) isShape__int() {}
 
-type Shape__Int_Wrapped struct {
-    _0 Wrapper__Int
+type Shape__int_Wrapped struct {
+    _0 Wrapper__int
 }
 
-func (_ Shape__Int_Wrapped) isShape__Int() {}
+func (_ Shape__int_Wrapped) isShape__int() {}
 
-type Shape__Int_Origin struct {}
+type Shape__int_Origin struct {}
 
-func (_ Shape__Int_Origin) isShape__Int() {}
+func (_ Shape__int_Origin) isShape__int() {}
 
-type Shape__Unit interface {
-    isShape__Unit()
+type Shape__unit interface {
+    isShape__unit()
 }
 
-type Shape__Unit_Dot struct {
+type Shape__unit_Dot struct {
     _0 Point
 }
 
-func (_ Shape__Unit_Dot) isShape__Unit() {}
+func (_ Shape__unit_Dot) isShape__unit() {}
 
-type Shape__Unit_Wrapped struct {
-    _0 Wrapper__Unit
+type Shape__unit_Wrapped struct {
+    _0 Wrapper__unit
 }
 
-func (_ Shape__Unit_Wrapped) isShape__Unit() {}
+func (_ Shape__unit_Wrapped) isShape__unit() {}
 
-type Shape__Unit_Origin struct {}
+type Shape__unit_Origin struct {}
 
-func (_ Shape__Unit_Origin) isShape__Unit() {}
+func (_ Shape__unit_Origin) isShape__unit() {}
 
-func bounce_int(shape__0 Shape__Int) Shape__Int {
-    var ret57 Shape__Int
+func bounce_int(shape__0 Shape__int) Shape__int {
+    var ret57 Shape__int
     switch shape__0 := shape__0.(type) {
-    case Shape__Int_Dot:
+    case Shape__int_Dot:
         var x0 Point = shape__0._0
         var point__1 Point = x0
-        ret57 = Shape__Int_Dot{
+        ret57 = Shape__int_Dot{
             _0: point__1,
         }
-    case Shape__Int_Wrapped:
-        var x1 Wrapper__Int = shape__0._0
-        var inner__2 Wrapper__Int = x1
-        ret57 = Shape__Int_Wrapped{
+    case Shape__int_Wrapped:
+        var x1 Wrapper__int = shape__0._0
+        var inner__2 Wrapper__int = x1
+        ret57 = Shape__int_Wrapped{
             _0: inner__2,
         }
-    case Shape__Int_Origin:
-        ret57 = Shape__Int_Origin{}
+    case Shape__int_Origin:
+        ret57 = Shape__int_Origin{}
     }
     return ret57
 }
 
-func wrap_unit(value__3 Wrapper__Unit) Shape__Unit {
-    var ret58 Shape__Unit
-    ret58 = Shape__Unit_Wrapped{
+func wrap_unit(value__3 Wrapper__unit) Shape__unit {
+    var ret58 Shape__unit
+    ret58 = Shape__unit_Wrapped{
         _0: value__3,
     }
     return ret58
 }
 
-func pick(flag__4 bool, point__5 Point, wrapper__6 Wrapper__Int) Shape__Int {
-    var ret59 Shape__Int
+func pick(flag__4 bool, point__5 Point, wrapper__6 Wrapper__int) Shape__int {
+    var ret59 Shape__int
     switch flag__4 {
     case true:
-        ret59 = Shape__Int_Dot{
+        ret59 = Shape__int_Dot{
             _0: point__5,
         }
     case false:
-        ret59 = Shape__Int_Wrapped{
+        ret59 = Shape__int_Wrapped{
             _0: wrapper__6,
         }
     }
@@ -164,65 +164,65 @@ func point_to_string(point__8 Point) string {
     return ret60
 }
 
-func wrapper_int_to_string(wrapper__14 Wrapper__Int) string {
+func wrapper_int_to_string(wrapper__14 Wrapper__int) string {
     var ret61 string
-    var mtmp7 Wrapper__Int = wrapper__14
+    var mtmp7 Wrapper__int = wrapper__14
     var x8 int = mtmp7.value
     var value__15 int = x8
     var t27 string = int_to_string(value__15)
-    var prefix__16 string = string_add("Wrapper[Int] { value: ", t27)
+    var prefix__16 string = string_add("Wrapper[int] { value: ", t27)
     ret61 = string_add(prefix__16, " }")
     return ret61
 }
 
-func wrapper_unit_to_string(wrapper__17 Wrapper__Unit) string {
+func wrapper_unit_to_string(wrapper__17 Wrapper__unit) string {
     var ret62 string
-    var mtmp9 Wrapper__Unit = wrapper__17
+    var mtmp9 Wrapper__unit = wrapper__17
     var x10 struct{} = mtmp9.value
     var value__18 struct{} = x10
     var t28 string = unit_to_string(value__18)
-    var prefix__19 string = string_add("Wrapper[Unit] { value: ", t28)
+    var prefix__19 string = string_add("Wrapper[unit] { value: ", t28)
     ret62 = string_add(prefix__19, " }")
     return ret62
 }
 
-func shape_int_to_string(shape__20 Shape__Int) string {
+func shape_int_to_string(shape__20 Shape__int) string {
     var ret63 string
     switch shape__20 := shape__20.(type) {
-    case Shape__Int_Dot:
+    case Shape__int_Dot:
         var x11 Point = shape__20._0
         var point__21 Point = x11
         var t29 string = point_to_string(point__21)
         var prefix__22 string = string_add("Shape::Dot(", t29)
         ret63 = string_add(prefix__22, ")")
-    case Shape__Int_Wrapped:
-        var x12 Wrapper__Int = shape__20._0
-        var wrapper__23 Wrapper__Int = x12
+    case Shape__int_Wrapped:
+        var x12 Wrapper__int = shape__20._0
+        var wrapper__23 Wrapper__int = x12
         var t30 string = wrapper_int_to_string(wrapper__23)
         var prefix__24 string = string_add("Shape::Wrapped(", t30)
         ret63 = string_add(prefix__24, ")")
-    case Shape__Int_Origin:
+    case Shape__int_Origin:
         ret63 = "Shape::Origin"
     }
     return ret63
 }
 
-func shape_unit_to_string(shape__25 Shape__Unit) string {
+func shape_unit_to_string(shape__25 Shape__unit) string {
     var ret64 string
     switch shape__25 := shape__25.(type) {
-    case Shape__Unit_Dot:
+    case Shape__unit_Dot:
         var x13 Point = shape__25._0
         var point__26 Point = x13
         var t31 string = point_to_string(point__26)
         var prefix__27 string = string_add("Shape::Dot(", t31)
         ret64 = string_add(prefix__27, ")")
-    case Shape__Unit_Wrapped:
-        var x14 Wrapper__Unit = shape__25._0
-        var wrapper__28 Wrapper__Unit = x14
+    case Shape__unit_Wrapped:
+        var x14 Wrapper__unit = shape__25._0
+        var wrapper__28 Wrapper__unit = x14
         var t32 string = wrapper_unit_to_string(wrapper__28)
         var prefix__29 string = string_add("Shape::Wrapped(", t32)
         ret64 = string_add(prefix__29, ")")
-    case Shape__Unit_Origin:
+    case Shape__unit_Origin:
         ret64 = "Shape::Origin"
     }
     return ret64
@@ -236,31 +236,31 @@ func main0() struct{} {
     }
     var t33 string = point_to_string(t34)
     string_println(t33)
-    var t36 Wrapper__Int = Wrapper__Int{
+    var t36 Wrapper__int = Wrapper__int{
         value: 7,
     }
     var t35 string = wrapper_int_to_string(t36)
     string_println(t35)
-    var t38 Wrapper__Unit = Wrapper__Unit{
+    var t38 Wrapper__unit = Wrapper__unit{
         value: struct{}{},
     }
     var t37 string = wrapper_unit_to_string(t38)
     string_println(t37)
-    var t39 Shape__Int = Shape__Int_Origin{}
-    var bounced_origin__30 Shape__Int = bounce_int(t39)
+    var t39 Shape__int = Shape__int_Origin{}
+    var bounced_origin__30 Shape__int = bounce_int(t39)
     var t42 Point = Point{
         x: 3,
         y: 4,
     }
-    var t41 Shape__Int = Shape__Int_Dot{
+    var t41 Shape__int = Shape__int_Dot{
         _0: t42,
     }
     var t40 string = shape_int_to_string(t41)
     string_println(t40)
-    var t45 Wrapper__Int = Wrapper__Int{
+    var t45 Wrapper__int = Wrapper__int{
         value: 7,
     }
-    var t44 Shape__Int = Shape__Int_Wrapped{
+    var t44 Shape__int = Shape__int_Wrapped{
         _0: t45,
     }
     var t43 string = shape_int_to_string(t44)
@@ -271,37 +271,37 @@ func main0() struct{} {
         x: 3,
         y: 4,
     }
-    var t48 Shape__Unit = Shape__Unit_Dot{
+    var t48 Shape__unit = Shape__unit_Dot{
         _0: t49,
     }
     var t47 string = shape_unit_to_string(t48)
     string_println(t47)
-    var t52 Wrapper__Unit = Wrapper__Unit{
+    var t52 Wrapper__unit = Wrapper__unit{
         value: struct{}{},
     }
-    var t51 Shape__Unit = Shape__Unit_Wrapped{
+    var t51 Shape__unit = Shape__unit_Wrapped{
         _0: t52,
     }
     var t50 string = shape_unit_to_string(t51)
     string_println(t50)
-    var t54 Shape__Unit = Shape__Unit_Origin{}
+    var t54 Shape__unit = Shape__unit_Origin{}
     var t53 string = shape_unit_to_string(t54)
     string_println(t53)
-    var t56 Shape__Int = Shape__Int_Origin{}
-    var t55 Shape__Int = bounce_int(t56)
-    describe__T_Int(t55)
+    var t56 Shape__int = Shape__int_Origin{}
+    var t55 Shape__int = bounce_int(t56)
+    describe__T_int(t55)
     ret65 = string_println("struct enums!")
     return ret65
 }
 
-func describe__T_Int(shape__7 Shape__Int) int {
+func describe__T_int(shape__7 Shape__int) int {
     var ret66 int
     switch shape__7.(type) {
-    case Shape__Int_Dot:
+    case Shape__int_Dot:
         ret66 = 1
-    case Shape__Int_Wrapped:
+    case Shape__int_Wrapped:
         ret66 = 2
-    case Shape__Int_Origin:
+    case Shape__int_Origin:
         ret66 = 0
     }
     return ret66

--- a/crates/compiler/src/tests/cases/020.src.mono
+++ b/crates/compiler/src/tests/cases/020.src.mono
@@ -1,37 +1,37 @@
-fn bounce_int(shape/0: Shape__Int) -> Shape__Int {
+fn bounce_int(shape/0: Shape__int) -> Shape__int {
   match shape/0 {
-    Shape__Int::Dot(x0) => {
-      let x0 = Shape__Int::Dot._0(shape/0) in
+    Shape__int::Dot(x0) => {
+      let x0 = Shape__int::Dot._0(shape/0) in
       let point/1 = x0 in
-      Shape__Int::Dot(point/1)
+      Shape__int::Dot(point/1)
     },
-    Shape__Int::Wrapped(x1) => {
-      let x1 = Shape__Int::Wrapped._0(shape/0) in
+    Shape__int::Wrapped(x1) => {
+      let x1 = Shape__int::Wrapped._0(shape/0) in
       let inner/2 = x1 in
-      Shape__Int::Wrapped(inner/2)
+      Shape__int::Wrapped(inner/2)
     },
-    Shape__Int::Origin => {
-      Shape__Int::Origin
+    Shape__int::Origin => {
+      Shape__int::Origin
     },
   }
 }
 
-fn wrap_unit(value/3: Wrapper__Unit) -> Shape__Unit {
-  Shape__Unit::Wrapped(value/3)
+fn wrap_unit(value/3: Wrapper__unit) -> Shape__unit {
+  Shape__unit::Wrapped(value/3)
 }
 
-fn pick(flag/4: Bool, point/5: Point, wrapper/6: Wrapper__Int) -> Shape__Int {
+fn pick(flag/4: bool, point/5: Point, wrapper/6: Wrapper__int) -> Shape__int {
   match flag/4 {
     true => {
-      Shape__Int::Dot(point/5)
+      Shape__int::Dot(point/5)
     },
     false => {
-      Shape__Int::Wrapped(wrapper/6)
+      Shape__int::Wrapped(wrapper/6)
     },
   }
 }
 
-fn point_to_string(point/8: Point) -> String {
+fn point_to_string(point/8: Point) -> string {
   let mtmp4 = point/8 in
   let x5 = Point.x(mtmp4) in
   let x6 = Point.y(mtmp4) in
@@ -43,88 +43,88 @@ fn point_to_string(point/8: Point) -> String {
   string_add(with_y/13, " }")
 }
 
-fn wrapper_int_to_string(wrapper/14: Wrapper__Int) -> String {
+fn wrapper_int_to_string(wrapper/14: Wrapper__int) -> string {
   let mtmp7 = wrapper/14 in
-  let x8 = Wrapper__Int.value(mtmp7) in
+  let x8 = Wrapper__int.value(mtmp7) in
   let value/15 = x8 in
-  let prefix/16 = string_add("Wrapper[Int] { value: ", int_to_string(value/15)) in
+  let prefix/16 = string_add("Wrapper[int] { value: ", int_to_string(value/15)) in
   string_add(prefix/16, " }")
 }
 
-fn wrapper_unit_to_string(wrapper/17: Wrapper__Unit) -> String {
+fn wrapper_unit_to_string(wrapper/17: Wrapper__unit) -> string {
   let mtmp9 = wrapper/17 in
-  let x10 = Wrapper__Unit.value(mtmp9) in
+  let x10 = Wrapper__unit.value(mtmp9) in
   let value/18 = x10 in
-  let prefix/19 = string_add("Wrapper[Unit] { value: ", unit_to_string(value/18)) in
+  let prefix/19 = string_add("Wrapper[unit] { value: ", unit_to_string(value/18)) in
   string_add(prefix/19, " }")
 }
 
-fn shape_int_to_string(shape/20: Shape__Int) -> String {
+fn shape_int_to_string(shape/20: Shape__int) -> string {
   match shape/20 {
-    Shape__Int::Dot(x11) => {
-      let x11 = Shape__Int::Dot._0(shape/20) in
+    Shape__int::Dot(x11) => {
+      let x11 = Shape__int::Dot._0(shape/20) in
       let point/21 = x11 in
       let prefix/22 = string_add("Shape::Dot(", point_to_string(point/21)) in
       string_add(prefix/22, ")")
     },
-    Shape__Int::Wrapped(x12) => {
-      let x12 = Shape__Int::Wrapped._0(shape/20) in
+    Shape__int::Wrapped(x12) => {
+      let x12 = Shape__int::Wrapped._0(shape/20) in
       let wrapper/23 = x12 in
       let prefix/24 = string_add("Shape::Wrapped(", wrapper_int_to_string(wrapper/23)) in
       string_add(prefix/24, ")")
     },
-    Shape__Int::Origin => {
+    Shape__int::Origin => {
       "Shape::Origin"
     },
   }
 }
 
-fn shape_unit_to_string(shape/25: Shape__Unit) -> String {
+fn shape_unit_to_string(shape/25: Shape__unit) -> string {
   match shape/25 {
-    Shape__Unit::Dot(x13) => {
-      let x13 = Shape__Unit::Dot._0(shape/25) in
+    Shape__unit::Dot(x13) => {
+      let x13 = Shape__unit::Dot._0(shape/25) in
       let point/26 = x13 in
       let prefix/27 = string_add("Shape::Dot(", point_to_string(point/26)) in
       string_add(prefix/27, ")")
     },
-    Shape__Unit::Wrapped(x14) => {
-      let x14 = Shape__Unit::Wrapped._0(shape/25) in
+    Shape__unit::Wrapped(x14) => {
+      let x14 = Shape__unit::Wrapped._0(shape/25) in
       let wrapper/28 = x14 in
       let prefix/29 = string_add("Shape::Wrapped(", wrapper_unit_to_string(wrapper/28)) in
       string_add(prefix/29, ")")
     },
-    Shape__Unit::Origin => {
+    Shape__unit::Origin => {
       "Shape::Origin"
     },
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp15 = string_println(point_to_string(Point(3, 4))) in
-  let mtmp16 = string_println(wrapper_int_to_string(Wrapper__Int(7))) in
-  let mtmp17 = string_println(wrapper_unit_to_string(Wrapper__Unit(()))) in
-  let bounced_origin/30 = bounce_int(Shape__Int::Origin) in
-  let mtmp18 = string_println(shape_int_to_string(Shape__Int::Dot(Point(3, 4)))) in
-  let mtmp19 = string_println(shape_int_to_string(Shape__Int::Wrapped(Wrapper__Int(7)))) in
+  let mtmp16 = string_println(wrapper_int_to_string(Wrapper__int(7))) in
+  let mtmp17 = string_println(wrapper_unit_to_string(Wrapper__unit(()))) in
+  let bounced_origin/30 = bounce_int(Shape__int::Origin) in
+  let mtmp18 = string_println(shape_int_to_string(Shape__int::Dot(Point(3, 4)))) in
+  let mtmp19 = string_println(shape_int_to_string(Shape__int::Wrapped(Wrapper__int(7)))) in
   let mtmp20 = string_println(shape_int_to_string(bounced_origin/30)) in
-  let mtmp21 = string_println(shape_unit_to_string(Shape__Unit::Dot(Point(3, 4)))) in
-  let mtmp22 = string_println(shape_unit_to_string(Shape__Unit::Wrapped(Wrapper__Unit(())))) in
-  let mtmp23 = string_println(shape_unit_to_string(Shape__Unit::Origin)) in
-  let mtmp24 = describe__T_Int(bounce_int(Shape__Int::Origin)) in
+  let mtmp21 = string_println(shape_unit_to_string(Shape__unit::Dot(Point(3, 4)))) in
+  let mtmp22 = string_println(shape_unit_to_string(Shape__unit::Wrapped(Wrapper__unit(())))) in
+  let mtmp23 = string_println(shape_unit_to_string(Shape__unit::Origin)) in
+  let mtmp24 = describe__T_int(bounce_int(Shape__int::Origin)) in
   string_println("struct enums!")
 }
 
-fn describe__T_Int(shape/7: Shape__Int) -> Int {
+fn describe__T_int(shape/7: Shape__int) -> int {
   match shape/7 {
-    Shape__Int::Dot(x2) => {
-      let x2 = Shape__Int::Dot._0(shape/7) in
+    Shape__int::Dot(x2) => {
+      let x2 = Shape__int::Dot._0(shape/7) in
       1
     },
-    Shape__Int::Wrapped(x3) => {
-      let x3 = Shape__Int::Wrapped._0(shape/7) in
+    Shape__int::Wrapped(x3) => {
+      let x3 = Shape__int::Wrapped._0(shape/7) in
       2
     },
-    Shape__Int::Origin => {
+    Shape__int::Origin => {
       0
     },
   }

--- a/crates/compiler/src/tests/cases/020.src.out
+++ b/crates/compiler/src/tests/cases/020.src.out
@@ -1,10 +1,10 @@
 Point { x: 3, y: 4 }
-Wrapper[Int] { value: 7 }
-Wrapper[Unit] { value: () }
+Wrapper[int] { value: 7 }
+Wrapper[unit] { value: () }
 Shape::Dot(Point { x: 3, y: 4 })
-Shape::Wrapped(Wrapper[Int] { value: 7 })
+Shape::Wrapped(Wrapper[int] { value: 7 })
 Shape::Origin
 Shape::Dot(Point { x: 3, y: 4 })
-Shape::Wrapped(Wrapper[Unit] { value: () })
+Shape::Wrapped(Wrapper[unit] { value: () })
 Shape::Origin
 struct enums!

--- a/crates/compiler/src/tests/cases/020.src.tast
+++ b/crates/compiler/src/tests/cases/020.src.tast
@@ -1,23 +1,23 @@
-fn bounce_int(shape/0: Shape[Int]) -> Shape[Int] {
-  match (shape/0 : Shape[Int]) {
+fn bounce_int(shape/0: Shape[int]) -> Shape[int] {
+  match (shape/0 : Shape[int]) {
       Shape::Dot(point/1: Point) => Shape::Dot((point/1 : Point)),
-      Shape::Wrapped(inner/2: Wrapper[Int]) => Shape::Wrapped((inner/2 : Wrapper[Int])),
+      Shape::Wrapped(inner/2: Wrapper[int]) => Shape::Wrapped((inner/2 : Wrapper[int])),
       Shape::Origin => Shape::Origin,
   }
 }
 
-fn wrap_unit(value/3: Wrapper[Unit]) -> Shape[Unit] {
-  Shape::Wrapped((value/3 : Wrapper[Unit]))
+fn wrap_unit(value/3: Wrapper[unit]) -> Shape[unit] {
+  Shape::Wrapped((value/3 : Wrapper[unit]))
 }
 
-fn pick(flag/4: Bool, point/5: Point, wrapper/6: Wrapper[Int]) -> Shape[Int] {
-  match (flag/4 : Bool) {
+fn pick(flag/4: bool, point/5: Point, wrapper/6: Wrapper[int]) -> Shape[int] {
+  match (flag/4 : bool) {
       true => Shape::Dot((point/5 : Point)),
-      false => Shape::Wrapped((wrapper/6 : Wrapper[Int])),
+      false => Shape::Wrapped((wrapper/6 : Wrapper[int])),
   }
 }
 
-fn describe(shape/7: Shape[T]) -> Int {
+fn describe(shape/7: Shape[T]) -> int {
   match (shape/7 : Shape[T]) {
       Shape::Dot(_ : Point) => 1,
       Shape::Wrapped(_ : Wrapper[T]) => 2,
@@ -25,57 +25,57 @@ fn describe(shape/7: Shape[T]) -> Int {
   }
 }
 
-fn point_to_string(point/8: Point) -> String {
-  let Point(x/9: Int, y/10: Int) = (point/8 : Point) in
-  let with_x/11: String = string_add("Point { x: ", int_to_string((x/9 : Int))) in
-  let with_y_label/12: String = string_add((with_x/11 : String), ", y: ") in
-  let with_y/13: String = string_add((with_y_label/12 : String), int_to_string((y/10 : Int))) in
-  string_add((with_y/13 : String), " }")
+fn point_to_string(point/8: Point) -> string {
+  let Point(x/9: int, y/10: int) = (point/8 : Point) in
+  let with_x/11: string = string_add("Point { x: ", int_to_string((x/9 : int))) in
+  let with_y_label/12: string = string_add((with_x/11 : string), ", y: ") in
+  let with_y/13: string = string_add((with_y_label/12 : string), int_to_string((y/10 : int))) in
+  string_add((with_y/13 : string), " }")
 }
 
-fn wrapper_int_to_string(wrapper/14: Wrapper[Int]) -> String {
-  let Wrapper(value/15: Int) = (wrapper/14 : Wrapper[Int]) in
-  let prefix/16: String = string_add("Wrapper[Int] { value: ", int_to_string((value/15 : Int))) in
-  string_add((prefix/16 : String), " }")
+fn wrapper_int_to_string(wrapper/14: Wrapper[int]) -> string {
+  let Wrapper(value/15: int) = (wrapper/14 : Wrapper[int]) in
+  let prefix/16: string = string_add("Wrapper[int] { value: ", int_to_string((value/15 : int))) in
+  string_add((prefix/16 : string), " }")
 }
 
-fn wrapper_unit_to_string(wrapper/17: Wrapper[Unit]) -> String {
-  let Wrapper(value/18: Unit) = (wrapper/17 : Wrapper[Unit]) in
-  let prefix/19: String = string_add("Wrapper[Unit] { value: ", unit_to_string((value/18 : Unit))) in
-  string_add((prefix/19 : String), " }")
+fn wrapper_unit_to_string(wrapper/17: Wrapper[unit]) -> string {
+  let Wrapper(value/18: unit) = (wrapper/17 : Wrapper[unit]) in
+  let prefix/19: string = string_add("Wrapper[unit] { value: ", unit_to_string((value/18 : unit))) in
+  string_add((prefix/19 : string), " }")
 }
 
-fn shape_int_to_string(shape/20: Shape[Int]) -> String {
-  match (shape/20 : Shape[Int]) {
-      Shape::Dot(point/21: Point) => let prefix/22: String = string_add("Shape::Dot(", point_to_string((point/21 : Point))) in
-        string_add((prefix/22 : String), ")"),
-      Shape::Wrapped(wrapper/23: Wrapper[Int]) => let prefix/24: String = string_add("Shape::Wrapped(", wrapper_int_to_string((wrapper/23 : Wrapper[Int]))) in
-        string_add((prefix/24 : String), ")"),
+fn shape_int_to_string(shape/20: Shape[int]) -> string {
+  match (shape/20 : Shape[int]) {
+      Shape::Dot(point/21: Point) => let prefix/22: string = string_add("Shape::Dot(", point_to_string((point/21 : Point))) in
+        string_add((prefix/22 : string), ")"),
+      Shape::Wrapped(wrapper/23: Wrapper[int]) => let prefix/24: string = string_add("Shape::Wrapped(", wrapper_int_to_string((wrapper/23 : Wrapper[int]))) in
+        string_add((prefix/24 : string), ")"),
       Shape::Origin => "Shape::Origin",
   }
 }
 
-fn shape_unit_to_string(shape/25: Shape[Unit]) -> String {
-  match (shape/25 : Shape[Unit]) {
-      Shape::Dot(point/26: Point) => let prefix/27: String = string_add("Shape::Dot(", point_to_string((point/26 : Point))) in
-        string_add((prefix/27 : String), ")"),
-      Shape::Wrapped(wrapper/28: Wrapper[Unit]) => let prefix/29: String = string_add("Shape::Wrapped(", wrapper_unit_to_string((wrapper/28 : Wrapper[Unit]))) in
-        string_add((prefix/29 : String), ")"),
+fn shape_unit_to_string(shape/25: Shape[unit]) -> string {
+  match (shape/25 : Shape[unit]) {
+      Shape::Dot(point/26: Point) => let prefix/27: string = string_add("Shape::Dot(", point_to_string((point/26 : Point))) in
+        string_add((prefix/27 : string), ")"),
+      Shape::Wrapped(wrapper/28: Wrapper[unit]) => let prefix/29: string = string_add("Shape::Wrapped(", wrapper_unit_to_string((wrapper/28 : Wrapper[unit]))) in
+        string_add((prefix/29 : string), ")"),
       Shape::Origin => "Shape::Origin",
   }
 }
 
-fn main() -> Unit {
-  let _ : Unit = string_println(point_to_string(Point(3, 4))) in
-  let _ : Unit = string_println(wrapper_int_to_string(Wrapper(7))) in
-  let _ : Unit = string_println(wrapper_unit_to_string(Wrapper(()))) in
-  let bounced_origin/30: Shape[Int] = bounce_int(Shape::Origin) in
-  let _ : Unit = string_println(shape_int_to_string(Shape::Dot(Point(3, 4)))) in
-  let _ : Unit = string_println(shape_int_to_string(Shape::Wrapped(Wrapper(7)))) in
-  let _ : Unit = string_println(shape_int_to_string((bounced_origin/30 : Shape[Int]))) in
-  let _ : Unit = string_println(shape_unit_to_string(Shape::Dot(Point(3, 4)))) in
-  let _ : Unit = string_println(shape_unit_to_string(Shape::Wrapped(Wrapper(())))) in
-  let _ : Unit = string_println(shape_unit_to_string(Shape::Origin)) in
-  let _ : Int = describe(bounce_int(Shape::Origin)) in
+fn main() -> unit {
+  let _ : unit = string_println(point_to_string(Point(3, 4))) in
+  let _ : unit = string_println(wrapper_int_to_string(Wrapper(7))) in
+  let _ : unit = string_println(wrapper_unit_to_string(Wrapper(()))) in
+  let bounced_origin/30: Shape[int] = bounce_int(Shape::Origin) in
+  let _ : unit = string_println(shape_int_to_string(Shape::Dot(Point(3, 4)))) in
+  let _ : unit = string_println(shape_int_to_string(Shape::Wrapped(Wrapper(7)))) in
+  let _ : unit = string_println(shape_int_to_string((bounced_origin/30 : Shape[int]))) in
+  let _ : unit = string_println(shape_unit_to_string(Shape::Dot(Point(3, 4)))) in
+  let _ : unit = string_println(shape_unit_to_string(Shape::Wrapped(Wrapper(())))) in
+  let _ : unit = string_println(shape_unit_to_string(Shape::Origin)) in
+  let _ : int = describe(bounce_int(Shape::Origin)) in
   string_println("struct enums!")
 }

--- a/crates/compiler/src/tests/cases/021.src
+++ b/crates/compiler/src/tests/cases/021.src
@@ -1,4 +1,4 @@
-fn match_int(n: Int) -> Int {
+fn match_int(n: int) -> int {
   match n {
     0 => 10,
     1 => 20,
@@ -6,14 +6,14 @@ fn match_int(n: Int) -> Int {
   }
 }
 
-fn wildcard_first(n: Int) -> Int {
+fn wildcard_first(n: int) -> int {
   match n {
     _ => 40,
     0 => 50,
   }
 }
 
-fn wildcard_middle(n: Int) -> Int {
+fn wildcard_middle(n: int) -> int {
   match n {
     2 => 90,
     _ => 100,
@@ -21,7 +21,7 @@ fn wildcard_middle(n: Int) -> Int {
   }
 }
 
-fn repeated(n: Int) -> Int {
+fn repeated(n: int) -> int {
   match n {
     1 => 60,
     1 => 70,

--- a/crates/compiler/src/tests/cases/021.src.anf
+++ b/crates/compiler/src/tests/cases/021.src.anf
@@ -1,4 +1,4 @@
-fn match_int(n/0: Int) -> Int {
+fn match_int(n/0: int) -> int {
   match n/0 {
     0 => {
       10
@@ -10,11 +10,11 @@ fn match_int(n/0: Int) -> Int {
   }
 }
 
-fn wildcard_first(n/1: Int) -> Int {
+fn wildcard_first(n/1: int) -> int {
   40
 }
 
-fn wildcard_middle(n/2: Int) -> Int {
+fn wildcard_middle(n/2: int) -> int {
   match n/2 {
     2 => {
       90
@@ -26,7 +26,7 @@ fn wildcard_middle(n/2: Int) -> Int {
   }
 }
 
-fn repeated(n/3: Int) -> Int {
+fn repeated(n/3: int) -> int {
   match n/3 {
     1 => {
       60
@@ -35,7 +35,7 @@ fn repeated(n/3: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t8 = match_int(0) in
   let t7 = int_to_string(t8) in
   let mtmp0 = string_println(t7) in

--- a/crates/compiler/src/tests/cases/021.src.ast
+++ b/crates/compiler/src/tests/cases/021.src.ast
@@ -1,4 +1,4 @@
-fn match_int(n: Int) -> Int {
+fn match_int(n: int) -> int {
     match n {
         0 => 10,
         1 => 20,
@@ -6,14 +6,14 @@ fn match_int(n: Int) -> Int {
     }
 }
 
-fn wildcard_first(n: Int) -> Int {
+fn wildcard_first(n: int) -> int {
     match n {
         _ => 40,
         0 => 50,
     }
 }
 
-fn wildcard_middle(n: Int) -> Int {
+fn wildcard_middle(n: int) -> int {
     match n {
         2 => 90,
         _ => 100,
@@ -21,7 +21,7 @@ fn wildcard_middle(n: Int) -> Int {
     }
 }
 
-fn repeated(n: Int) -> Int {
+fn repeated(n: int) -> int {
     match n {
         1 => 60,
         1 => 70,

--- a/crates/compiler/src/tests/cases/021.src.core
+++ b/crates/compiler/src/tests/cases/021.src.core
@@ -1,4 +1,4 @@
-fn match_int(n/0: Int) -> Int {
+fn match_int(n/0: int) -> int {
   match n/0 {
     0 => {
       10
@@ -10,11 +10,11 @@ fn match_int(n/0: Int) -> Int {
   }
 }
 
-fn wildcard_first(n/1: Int) -> Int {
+fn wildcard_first(n/1: int) -> int {
   40
 }
 
-fn wildcard_middle(n/2: Int) -> Int {
+fn wildcard_middle(n/2: int) -> int {
   match n/2 {
     2 => {
       90
@@ -26,7 +26,7 @@ fn wildcard_middle(n/2: Int) -> Int {
   }
 }
 
-fn repeated(n/3: Int) -> Int {
+fn repeated(n/3: int) -> int {
   match n/3 {
     1 => {
       60
@@ -35,7 +35,7 @@ fn repeated(n/3: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_println(int_to_string(match_int(0))) in
   let mtmp1 = string_println(int_to_string(match_int(5))) in
   let mtmp2 = string_println(int_to_string(wildcard_first(0))) in

--- a/crates/compiler/src/tests/cases/021.src.cst
+++ b/crates/compiler/src/tests/cases/021.src.cst
@@ -10,13 +10,13 @@ FILE@0..846
         Colon@14..15 ":"
         Whitespace@15..16 " "
         TYPE_INT@16..19
-          IntKeyword@16..19 "Int"
+          IntKeyword@16..19 "int"
       RParen@19..20 ")"
       Whitespace@20..21 " "
     Arrow@21..23 "->"
     Whitespace@23..24 " "
     TYPE_INT@24..28
-      IntKeyword@24..27 "Int"
+      IntKeyword@24..27 "int"
       Whitespace@27..28 " "
     BLOCK@28..88
       LBrace@28..29 "{"
@@ -75,13 +75,13 @@ FILE@0..846
         Colon@107..108 ":"
         Whitespace@108..109 " "
         TYPE_INT@109..112
-          IntKeyword@109..112 "Int"
+          IntKeyword@109..112 "int"
       RParen@112..113 ")"
       Whitespace@113..114 " "
     Arrow@114..116 "->"
     Whitespace@116..117 " "
     TYPE_INT@117..121
-      IntKeyword@117..120 "Int"
+      IntKeyword@117..120 "int"
       Whitespace@120..121 " "
     BLOCK@121..168
       LBrace@121..122 "{"
@@ -130,13 +130,13 @@ FILE@0..846
         Colon@188..189 ":"
         Whitespace@189..190 " "
         TYPE_INT@190..193
-          IntKeyword@190..193 "Int"
+          IntKeyword@190..193 "int"
       RParen@193..194 ")"
       Whitespace@194..195 " "
     Arrow@195..197 "->"
     Whitespace@197..198 " "
     TYPE_INT@198..202
-      IntKeyword@198..201 "Int"
+      IntKeyword@198..201 "int"
       Whitespace@201..202 " "
     BLOCK@202..264
       LBrace@202..203 "{"
@@ -195,13 +195,13 @@ FILE@0..846
         Colon@277..278 ":"
         Whitespace@278..279 " "
         TYPE_INT@279..282
-          IntKeyword@279..282 "Int"
+          IntKeyword@279..282 "int"
       RParen@282..283 ")"
       Whitespace@283..284 " "
     Arrow@284..286 "->"
     Whitespace@286..287 " "
     TYPE_INT@287..291
-      IntKeyword@287..290 "Int"
+      IntKeyword@287..290 "int"
       Whitespace@290..291 " "
     BLOCK@291..351
       LBrace@291..292 "{"

--- a/crates/compiler/src/tests/cases/021.src.mono
+++ b/crates/compiler/src/tests/cases/021.src.mono
@@ -1,4 +1,4 @@
-fn match_int(n/0: Int) -> Int {
+fn match_int(n/0: int) -> int {
   match n/0 {
     0 => {
       10
@@ -10,11 +10,11 @@ fn match_int(n/0: Int) -> Int {
   }
 }
 
-fn wildcard_first(n/1: Int) -> Int {
+fn wildcard_first(n/1: int) -> int {
   40
 }
 
-fn wildcard_middle(n/2: Int) -> Int {
+fn wildcard_middle(n/2: int) -> int {
   match n/2 {
     2 => {
       90
@@ -26,7 +26,7 @@ fn wildcard_middle(n/2: Int) -> Int {
   }
 }
 
-fn repeated(n/3: Int) -> Int {
+fn repeated(n/3: int) -> int {
   match n/3 {
     1 => {
       60
@@ -35,7 +35,7 @@ fn repeated(n/3: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_println(int_to_string(match_int(0))) in
   let mtmp1 = string_println(int_to_string(match_int(5))) in
   let mtmp2 = string_println(int_to_string(wildcard_first(0))) in

--- a/crates/compiler/src/tests/cases/021.src.tast
+++ b/crates/compiler/src/tests/cases/021.src.tast
@@ -1,41 +1,41 @@
-fn match_int(n/0: Int) -> Int {
-  match (n/0 : Int) {
+fn match_int(n/0: int) -> int {
+  match (n/0 : int) {
       0 => 10,
       1 => 20,
-      _ : Int => 30,
+      _ : int => 30,
   }
 }
 
-fn wildcard_first(n/1: Int) -> Int {
-  match (n/1 : Int) {
-      _ : Int => 40,
+fn wildcard_first(n/1: int) -> int {
+  match (n/1 : int) {
+      _ : int => 40,
       0 => 50,
   }
 }
 
-fn wildcard_middle(n/2: Int) -> Int {
-  match (n/2 : Int) {
+fn wildcard_middle(n/2: int) -> int {
+  match (n/2 : int) {
       2 => 90,
-      _ : Int => 100,
+      _ : int => 100,
       3 => 110,
   }
 }
 
-fn repeated(n/3: Int) -> Int {
-  match (n/3 : Int) {
+fn repeated(n/3: int) -> int {
+  match (n/3 : int) {
       1 => 60,
       1 => 70,
-      _ : Int => 80,
+      _ : int => 80,
   }
 }
 
-fn main() -> Unit {
-  let _ : Unit = string_println(int_to_string(match_int(0))) in
-  let _ : Unit = string_println(int_to_string(match_int(5))) in
-  let _ : Unit = string_println(int_to_string(wildcard_first(0))) in
-  let _ : Unit = string_println(int_to_string(wildcard_first(2))) in
-  let _ : Unit = string_println(int_to_string(wildcard_middle(2))) in
-  let _ : Unit = string_println(int_to_string(wildcard_middle(3))) in
-  let _ : Unit = string_println(int_to_string(repeated(1))) in
+fn main() -> unit {
+  let _ : unit = string_println(int_to_string(match_int(0))) in
+  let _ : unit = string_println(int_to_string(match_int(5))) in
+  let _ : unit = string_println(int_to_string(wildcard_first(0))) in
+  let _ : unit = string_println(int_to_string(wildcard_first(2))) in
+  let _ : unit = string_println(int_to_string(wildcard_middle(2))) in
+  let _ : unit = string_println(int_to_string(wildcard_middle(3))) in
+  let _ : unit = string_println(int_to_string(repeated(1))) in
   string_println(int_to_string(repeated(3)))
 }

--- a/crates/compiler/src/tests/cases/022.src
+++ b/crates/compiler/src/tests/cases/022.src
@@ -1,4 +1,4 @@
-fn match_string(s: String) -> Int {
+fn match_string(s: string) -> int {
   match s {
     "hello" => 1,
     "world" => 2,
@@ -6,14 +6,14 @@ fn match_string(s: String) -> Int {
   }
 }
 
-fn wildcard_position(s: String) -> Int {
+fn wildcard_position(s: string) -> int {
   match s {
     _ => 4,
     "world" => 5,
   }
 }
 
-fn repeated_string(s: String) -> Int {
+fn repeated_string(s: string) -> int {
   match s {
     "hello" => 6,
     "hello" => 7,

--- a/crates/compiler/src/tests/cases/022.src.anf
+++ b/crates/compiler/src/tests/cases/022.src.anf
@@ -1,4 +1,4 @@
-fn match_string(s/0: String) -> Int {
+fn match_string(s/0: string) -> int {
   match s/0 {
     "hello" => {
       1
@@ -10,11 +10,11 @@ fn match_string(s/0: String) -> Int {
   }
 }
 
-fn wildcard_position(s/1: String) -> Int {
+fn wildcard_position(s/1: string) -> int {
   4
 }
 
-fn repeated_string(s/2: String) -> Int {
+fn repeated_string(s/2: string) -> int {
   match s/2 {
     "hello" => {
       6
@@ -23,7 +23,7 @@ fn repeated_string(s/2: String) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t6 = match_string("hello") in
   let t5 = int_to_string(t6) in
   let mtmp0 = string_println(t5) in

--- a/crates/compiler/src/tests/cases/022.src.ast
+++ b/crates/compiler/src/tests/cases/022.src.ast
@@ -1,4 +1,4 @@
-fn match_string(s: String) -> Int {
+fn match_string(s: string) -> int {
     match s {
         "hello" => 1,
         "world" => 2,
@@ -6,14 +6,14 @@ fn match_string(s: String) -> Int {
     }
 }
 
-fn wildcard_position(s: String) -> Int {
+fn wildcard_position(s: string) -> int {
     match s {
         _ => 4,
         "world" => 5,
     }
 }
 
-fn repeated_string(s: String) -> Int {
+fn repeated_string(s: string) -> int {
     match s {
         "hello" => 6,
         "hello" => 7,

--- a/crates/compiler/src/tests/cases/022.src.core
+++ b/crates/compiler/src/tests/cases/022.src.core
@@ -1,4 +1,4 @@
-fn match_string(s/0: String) -> Int {
+fn match_string(s/0: string) -> int {
   match s/0 {
     "hello" => {
       1
@@ -10,11 +10,11 @@ fn match_string(s/0: String) -> Int {
   }
 }
 
-fn wildcard_position(s/1: String) -> Int {
+fn wildcard_position(s/1: string) -> int {
   4
 }
 
-fn repeated_string(s/2: String) -> Int {
+fn repeated_string(s/2: string) -> int {
   match s/2 {
     "hello" => {
       6
@@ -23,7 +23,7 @@ fn repeated_string(s/2: String) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_println(int_to_string(match_string("hello"))) in
   let mtmp1 = string_println(int_to_string(match_string("planet"))) in
   let mtmp2 = string_println(int_to_string(wildcard_position("world"))) in

--- a/crates/compiler/src/tests/cases/022.src.cst
+++ b/crates/compiler/src/tests/cases/022.src.cst
@@ -10,13 +10,13 @@ FILE@0..724
         Colon@17..18 ":"
         Whitespace@18..19 " "
         TYPE_STRING@19..25
-          StringKeyword@19..25 "String"
+          StringKeyword@19..25 "string"
       RParen@25..26 ")"
       Whitespace@26..27 " "
     Arrow@27..29 "->"
     Whitespace@29..30 " "
     TYPE_INT@30..34
-      IntKeyword@30..33 "Int"
+      IntKeyword@30..33 "int"
       Whitespace@33..34 " "
     BLOCK@34..103
       LBrace@34..35 "{"
@@ -75,13 +75,13 @@ FILE@0..724
         Colon@125..126 ":"
         Whitespace@126..127 " "
         TYPE_STRING@127..133
-          StringKeyword@127..133 "String"
+          StringKeyword@127..133 "string"
       RParen@133..134 ")"
       Whitespace@134..135 " "
     Arrow@135..137 "->"
     Whitespace@137..138 " "
     TYPE_INT@138..142
-      IntKeyword@138..141 "Int"
+      IntKeyword@138..141 "int"
       Whitespace@141..142 " "
     BLOCK@142..193
       LBrace@142..143 "{"
@@ -130,13 +130,13 @@ FILE@0..724
         Colon@213..214 ":"
         Whitespace@214..215 " "
         TYPE_STRING@215..221
-          StringKeyword@215..221 "String"
+          StringKeyword@215..221 "string"
       RParen@221..222 ")"
       Whitespace@222..223 " "
     Arrow@223..225 "->"
     Whitespace@225..226 " "
     TYPE_INT@226..230
-      IntKeyword@226..229 "Int"
+      IntKeyword@226..229 "int"
       Whitespace@229..230 " "
     BLOCK@230..299
       LBrace@230..231 "{"

--- a/crates/compiler/src/tests/cases/022.src.mono
+++ b/crates/compiler/src/tests/cases/022.src.mono
@@ -1,4 +1,4 @@
-fn match_string(s/0: String) -> Int {
+fn match_string(s/0: string) -> int {
   match s/0 {
     "hello" => {
       1
@@ -10,11 +10,11 @@ fn match_string(s/0: String) -> Int {
   }
 }
 
-fn wildcard_position(s/1: String) -> Int {
+fn wildcard_position(s/1: string) -> int {
   4
 }
 
-fn repeated_string(s/2: String) -> Int {
+fn repeated_string(s/2: string) -> int {
   match s/2 {
     "hello" => {
       6
@@ -23,7 +23,7 @@ fn repeated_string(s/2: String) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp0 = string_println(int_to_string(match_string("hello"))) in
   let mtmp1 = string_println(int_to_string(match_string("planet"))) in
   let mtmp2 = string_println(int_to_string(wildcard_position("world"))) in

--- a/crates/compiler/src/tests/cases/022.src.tast
+++ b/crates/compiler/src/tests/cases/022.src.tast
@@ -1,31 +1,31 @@
-fn match_string(s/0: String) -> Int {
-  match (s/0 : String) {
+fn match_string(s/0: string) -> int {
+  match (s/0 : string) {
       "hello" => 1,
       "world" => 2,
-      _ : String => 3,
+      _ : string => 3,
   }
 }
 
-fn wildcard_position(s/1: String) -> Int {
-  match (s/1 : String) {
-      _ : String => 4,
+fn wildcard_position(s/1: string) -> int {
+  match (s/1 : string) {
+      _ : string => 4,
       "world" => 5,
   }
 }
 
-fn repeated_string(s/2: String) -> Int {
-  match (s/2 : String) {
+fn repeated_string(s/2: string) -> int {
+  match (s/2 : string) {
       "hello" => 6,
       "hello" => 7,
-      _ : String => 8,
+      _ : string => 8,
   }
 }
 
-fn main() -> Unit {
-  let _ : Unit = string_println(int_to_string(match_string("hello"))) in
-  let _ : Unit = string_println(int_to_string(match_string("planet"))) in
-  let _ : Unit = string_println(int_to_string(wildcard_position("world"))) in
-  let _ : Unit = string_println(int_to_string(wildcard_position("sun"))) in
-  let _ : Unit = string_println(int_to_string(repeated_string("hello"))) in
+fn main() -> unit {
+  let _ : unit = string_println(int_to_string(match_string("hello"))) in
+  let _ : unit = string_println(int_to_string(match_string("planet"))) in
+  let _ : unit = string_println(int_to_string(wildcard_position("world"))) in
+  let _ : unit = string_println(int_to_string(wildcard_position("sun"))) in
+  let _ : unit = string_println(int_to_string(repeated_string("hello"))) in
   string_println(int_to_string(repeated_string("mars")))
 }

--- a/crates/compiler/src/tests/cases/023.src
+++ b/crates/compiler/src/tests/cases/023.src
@@ -1,4 +1,4 @@
-fn match_mixed_pair(pair: (Int, String)) -> Int {
+fn match_mixed_pair(pair: (int, string)) -> int {
   match pair {
     (0, "zero") => 1,
     (0, _) => 2,
@@ -9,12 +9,12 @@ fn match_mixed_pair(pair: (Int, String)) -> Int {
 }
 
 enum Mixed {
-  OnlyInt(Int),
-  OnlyStr(String),
-  Both(Int, String),
+  OnlyInt(int),
+  OnlyStr(string),
+  Both(int, string),
 }
 
-fn match_mixed_enum(value: Mixed) -> Int {
+fn match_mixed_enum(value: Mixed) -> int {
   match value {
     OnlyInt(0) => 6,
     OnlyInt(_) => 7,

--- a/crates/compiler/src/tests/cases/023.src.anf
+++ b/crates/compiler/src/tests/cases/023.src.anf
@@ -1,4 +1,4 @@
-fn match_mixed_pair(pair/0: (Int, String)) -> Int {
+fn match_mixed_pair(pair/0: (int, string)) -> int {
   let x0 = pair/0.0 in
   let x1 = pair/0.1 in
   match x1 {
@@ -30,7 +30,7 @@ fn match_mixed_pair(pair/0: (Int, String)) -> Int {
   }
 }
 
-fn match_mixed_enum(value/1: Mixed) -> Int {
+fn match_mixed_enum(value/1: Mixed) -> int {
   match value/1 {
     Tag_0 => {
       let x2 = Mixed::OnlyInt._0(value/1) in
@@ -73,7 +73,7 @@ fn match_mixed_enum(value/1: Mixed) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t20 = (0, "zero") in
   let t19 = match_mixed_pair(t20) in
   let t18 = int_to_string(t19) in

--- a/crates/compiler/src/tests/cases/023.src.ast
+++ b/crates/compiler/src/tests/cases/023.src.ast
@@ -1,4 +1,4 @@
-fn match_mixed_pair(pair: (Int, String)) -> Int {
+fn match_mixed_pair(pair: (int, string)) -> int {
     match pair {
         (0, "zero") => 1,
         (0, _) => 2,
@@ -9,12 +9,12 @@ fn match_mixed_pair(pair: (Int, String)) -> Int {
 }
 
 enum Mixed {
-    OnlyInt(Int),
-    OnlyStr(String),
-    Both(Int, String)
+    OnlyInt(int),
+    OnlyStr(string),
+    Both(int, string)
 }
 
-fn match_mixed_enum(value: Mixed) -> Int {
+fn match_mixed_enum(value: Mixed) -> int {
     match value {
         OnlyInt(0) => 6,
         OnlyInt(_) => 7,

--- a/crates/compiler/src/tests/cases/023.src.core
+++ b/crates/compiler/src/tests/cases/023.src.core
@@ -1,4 +1,4 @@
-fn match_mixed_pair(pair/0: (Int, String)) -> Int {
+fn match_mixed_pair(pair/0: (int, string)) -> int {
   let x0 = pair/0.0 in
   let x1 = pair/0.1 in
   match x1 {
@@ -30,7 +30,7 @@ fn match_mixed_pair(pair/0: (Int, String)) -> Int {
   }
 }
 
-fn match_mixed_enum(value/1: Mixed) -> Int {
+fn match_mixed_enum(value/1: Mixed) -> int {
   match value/1 {
     Mixed::OnlyInt(x2) => {
       let x2 = Mixed::OnlyInt._0(value/1) in
@@ -73,7 +73,7 @@ fn match_mixed_enum(value/1: Mixed) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp6 = string_println(int_to_string(match_mixed_pair((0, "zero")))) in
   let mtmp7 = string_println(int_to_string(match_mixed_pair((0, "other")))) in
   let mtmp8 = string_println(int_to_string(match_mixed_pair((1, "one")))) in

--- a/crates/compiler/src/tests/cases/023.src.cst
+++ b/crates/compiler/src/tests/cases/023.src.cst
@@ -13,18 +13,18 @@ FILE@0..1506
           TYPE_LIST@26..39
             LParen@26..27 "("
             TYPE_INT@27..30
-              IntKeyword@27..30 "Int"
+              IntKeyword@27..30 "int"
             Comma@30..31 ","
             Whitespace@31..32 " "
             TYPE_STRING@32..38
-              StringKeyword@32..38 "String"
+              StringKeyword@32..38 "string"
             RParen@38..39 ")"
       RParen@39..40 ")"
       Whitespace@40..41 " "
     Arrow@41..43 "->"
     Whitespace@43..44 " "
     TYPE_INT@44..48
-      IntKeyword@44..47 "Int"
+      IntKeyword@44..47 "int"
       Whitespace@47..48 " "
     BLOCK@48..166
       LBrace@48..49 "{"
@@ -133,7 +133,7 @@ FILE@0..1506
         TYPE_LIST@188..193
           LParen@188..189 "("
           TYPE_INT@189..192
-            IntKeyword@189..192 "Int"
+            IntKeyword@189..192 "int"
           RParen@192..193 ")"
       Comma@193..194 ","
       Whitespace@194..197 "\n  "
@@ -142,7 +142,7 @@ FILE@0..1506
         TYPE_LIST@204..212
           LParen@204..205 "("
           TYPE_STRING@205..211
-            StringKeyword@205..211 "String"
+            StringKeyword@205..211 "string"
           RParen@211..212 ")"
       Comma@212..213 ","
       Whitespace@213..216 "\n  "
@@ -151,11 +151,11 @@ FILE@0..1506
         TYPE_LIST@220..233
           LParen@220..221 "("
           TYPE_INT@221..224
-            IntKeyword@221..224 "Int"
+            IntKeyword@221..224 "int"
           Comma@224..225 ","
           Whitespace@225..226 " "
           TYPE_STRING@226..232
-            StringKeyword@226..232 "String"
+            StringKeyword@226..232 "string"
           RParen@232..233 ")"
       Comma@233..234 ","
       Whitespace@234..235 "\n"
@@ -178,7 +178,7 @@ FILE@0..1506
     Arrow@272..274 "->"
     Whitespace@274..275 " "
     TYPE_INT@275..279
-      IntKeyword@275..278 "Int"
+      IntKeyword@275..278 "int"
       Whitespace@278..279 " "
     BLOCK@279..491
       LBrace@279..280 "{"

--- a/crates/compiler/src/tests/cases/023.src.mono
+++ b/crates/compiler/src/tests/cases/023.src.mono
@@ -1,4 +1,4 @@
-fn match_mixed_pair(pair/0: (Int, String)) -> Int {
+fn match_mixed_pair(pair/0: (int, string)) -> int {
   let x0 = pair/0.0 in
   let x1 = pair/0.1 in
   match x1 {
@@ -30,7 +30,7 @@ fn match_mixed_pair(pair/0: (Int, String)) -> Int {
   }
 }
 
-fn match_mixed_enum(value/1: Mixed) -> Int {
+fn match_mixed_enum(value/1: Mixed) -> int {
   match value/1 {
     Mixed::OnlyInt(x2) => {
       let x2 = Mixed::OnlyInt._0(value/1) in
@@ -73,7 +73,7 @@ fn match_mixed_enum(value/1: Mixed) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let mtmp6 = string_println(int_to_string(match_mixed_pair((0, "zero")))) in
   let mtmp7 = string_println(int_to_string(match_mixed_pair((0, "other")))) in
   let mtmp8 = string_println(int_to_string(match_mixed_pair((1, "one")))) in

--- a/crates/compiler/src/tests/cases/023.src.tast
+++ b/crates/compiler/src/tests/cases/023.src.tast
@@ -1,38 +1,38 @@
-fn match_mixed_pair(pair/0: (Int, String)) -> Int {
-  match (pair/0 : (Int, String)) {
+fn match_mixed_pair(pair/0: (int, string)) -> int {
+  match (pair/0 : (int, string)) {
       (0, "zero") => 1,
-      (0, _ : String) => 2,
+      (0, _ : string) => 2,
       (1, "one") => 3,
-      (_ : Int, "zero") => 4,
-      _ : (Int, String) => 5,
+      (_ : int, "zero") => 4,
+      _ : (int, string) => 5,
   }
 }
 
-fn match_mixed_enum(value/1: Mixed) -> Int {
+fn match_mixed_enum(value/1: Mixed) -> int {
   match (value/1 : Mixed) {
       Mixed::OnlyInt(0) => 6,
-      Mixed::OnlyInt(_ : Int) => 7,
+      Mixed::OnlyInt(_ : int) => 7,
       Mixed::OnlyStr("zero") => 8,
-      Mixed::OnlyStr(_ : String) => 9,
+      Mixed::OnlyStr(_ : string) => 9,
       Mixed::Both(0, "zero") => 10,
-      Mixed::Both(0, _ : String) => 11,
-      Mixed::Both(_ : Int, "zero") => 12,
-      Mixed::Both(_ : Int, _ : String) => 13,
+      Mixed::Both(0, _ : string) => 11,
+      Mixed::Both(_ : int, "zero") => 12,
+      Mixed::Both(_ : int, _ : string) => 13,
   }
 }
 
-fn main() -> Unit {
-  let _ : Unit = string_println(int_to_string(match_mixed_pair((0, "zero")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_pair((0, "other")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_pair((1, "one")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_pair((2, "zero")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_pair((2, "two")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_enum(Mixed::OnlyInt(0)))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_enum(Mixed::OnlyInt(5)))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_enum(Mixed::OnlyStr("zero")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_enum(Mixed::OnlyStr("hello")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_enum(Mixed::Both(0, "zero")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_enum(Mixed::Both(0, "hello")))) in
-  let _ : Unit = string_println(int_to_string(match_mixed_enum(Mixed::Both(2, "zero")))) in
+fn main() -> unit {
+  let _ : unit = string_println(int_to_string(match_mixed_pair((0, "zero")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_pair((0, "other")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_pair((1, "one")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_pair((2, "zero")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_pair((2, "two")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_enum(Mixed::OnlyInt(0)))) in
+  let _ : unit = string_println(int_to_string(match_mixed_enum(Mixed::OnlyInt(5)))) in
+  let _ : unit = string_println(int_to_string(match_mixed_enum(Mixed::OnlyStr("zero")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_enum(Mixed::OnlyStr("hello")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_enum(Mixed::Both(0, "zero")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_enum(Mixed::Both(0, "hello")))) in
+  let _ : unit = string_println(int_to_string(match_mixed_enum(Mixed::Both(2, "zero")))) in
   string_println(int_to_string(match_mixed_enum(Mixed::Both(3, "three"))))
 }

--- a/crates/compiler/src/tests/examples/001_pattern_matching.src.anf
+++ b/crates/compiler/src/tests/examples/001_pattern_matching.src.anf
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let t51 = Tag_0 in
   let t52 = Tag_0 in
   let t50 = Expr::Add(t51, t52) in

--- a/crates/compiler/src/tests/examples/001_pattern_matching.src.core
+++ b/crates/compiler/src/tests/examples/001_pattern_matching.src.core
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = Expr::Mul(Expr::Add(Expr::Zero, Expr::Zero), Expr::Zero) in
   match a/0 {
     Expr::Zero => {

--- a/crates/compiler/src/tests/examples/001_pattern_matching.src.mono
+++ b/crates/compiler/src/tests/examples/001_pattern_matching.src.mono
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0 = Expr::Mul(Expr::Add(Expr::Zero, Expr::Zero), Expr::Zero) in
   match a/0 {
     Expr::Zero => {

--- a/crates/compiler/src/tests/examples/001_pattern_matching.src.tast
+++ b/crates/compiler/src/tests/examples/001_pattern_matching.src.tast
@@ -1,4 +1,4 @@
-fn main() -> Unit {
+fn main() -> unit {
   let a/0: Expr = Expr::Mul(Expr::Add(Expr::Zero, Expr::Zero), Expr::Zero) in
   match (a/0 : Expr) {
       Expr::Add(Expr::Zero, Expr::Zero) => string_print(int_to_string(0)),

--- a/crates/compiler/src/tests/examples/002_overloading.src
+++ b/crates/compiler/src/tests/examples/002_overloading.src
@@ -1,46 +1,46 @@
 trait Arith {
-    fn add(Self, Self) -> Int;
-    fn less(Self, Self) -> Bool;
+    fn add(Self, Self) -> int;
+    fn less(Self, Self) -> bool;
 }
 
-impl Arith for Int {
-    fn add(self: Int, other: Int) -> Int {
+impl Arith for int {
+    fn add(self: int, other: int) -> int {
         int_add(self, other)
     }
 
-    fn less(self: Int, other: Int) -> Bool {
+    fn less(self: int, other: int) -> bool {
         int_less(self, other)
     }
 }
 
 trait ToString {
-    fn to_string(Self) -> String;
+    fn to_string(Self) -> string;
 }
 
-impl ToString for Int {
-    fn to_string(self: Int) -> String {
+impl ToString for int {
+    fn to_string(self: int) -> string {
         int_to_string(self)
     }
 }
 
-impl ToString for Bool {
-    fn to_string(self: Bool) -> String {
+impl ToString for bool {
+    fn to_string(self: bool) -> string {
         bool_to_string(self)
     }
 }
 
 trait Output {
-    fn output(Self) -> Unit;
+    fn output(Self) -> unit;
 }
 
-impl Output for Int {
-    fn output(self: Int) -> Unit {
+impl Output for int {
+    fn output(self: int) -> unit {
         string_println(to_string(self))
     }
 }
 
-impl Output for Bool {
-    fn output(self: Bool) -> Unit {
+impl Output for bool {
+    fn output(self: bool) -> unit {
         string_println(to_string(self))
     }
 }

--- a/crates/compiler/src/tests/examples/002_overloading.src.anf
+++ b/crates/compiler/src/tests/examples/002_overloading.src.anf
@@ -1,41 +1,41 @@
-fn impl_Arith_Int_add(self/0: Int, other/1: Int) -> Int {
+fn impl_Arith_int_add(self/0: int, other/1: int) -> int {
   int_add(self/0, other/1)
 }
 
-fn impl_Arith_Int_less(self/2: Int, other/3: Int) -> Bool {
+fn impl_Arith_int_less(self/2: int, other/3: int) -> bool {
   int_less(self/2, other/3)
 }
 
-fn impl_ToString_Int_to_string(self/4: Int) -> String {
+fn impl_ToString_int_to_string(self/4: int) -> string {
   int_to_string(self/4)
 }
 
-fn impl_ToString_Bool_to_string(self/5: Bool) -> String {
+fn impl_ToString_bool_to_string(self/5: bool) -> string {
   bool_to_string(self/5)
 }
 
-fn impl_Output_Int_output(self/6: Int) -> Unit {
-  let t2 = impl_ToString_Int_to_string(self/6) in
+fn impl_Output_int_output(self/6: int) -> unit {
+  let t2 = impl_ToString_int_to_string(self/6) in
   string_println(t2)
 }
 
-fn impl_Output_Bool_output(self/7: Bool) -> Unit {
-  let t3 = impl_ToString_Bool_to_string(self/7) in
+fn impl_Output_bool_output(self/7: bool) -> unit {
+  let t3 = impl_ToString_bool_to_string(self/7) in
   string_println(t3)
 }
 
-fn main() -> Unit {
-  let a/9 = id__T_Int(1) in
-  let b/10 = id__T_Int(2) in
-  let c/11 = impl_Arith_Int_add(a/9, b/10) in
-  let mtmp0 = impl_Output_Int_output(c/11) in
-  let a/12 = id__T_Int(3) in
-  let b/13 = id__T_Int(4) in
-  let c/14 = impl_Arith_Int_less(a/12, b/13) in
-  let mtmp1 = impl_Output_Bool_output(c/14) in
+fn main() -> unit {
+  let a/9 = id__T_int(1) in
+  let b/10 = id__T_int(2) in
+  let c/11 = impl_Arith_int_add(a/9, b/10) in
+  let mtmp0 = impl_Output_int_output(c/11) in
+  let a/12 = id__T_int(3) in
+  let b/13 = id__T_int(4) in
+  let c/14 = impl_Arith_int_less(a/12, b/13) in
+  let mtmp1 = impl_Output_bool_output(c/14) in
   ()
 }
 
-fn id__T_Int(x/8: Int) -> Int {
+fn id__T_int(x/8: int) -> int {
   x/8
 }

--- a/crates/compiler/src/tests/examples/002_overloading.src.ast
+++ b/crates/compiler/src/tests/examples/002_overloading.src.ast
@@ -1,45 +1,45 @@
 trait Arith {
-  fn add(Self, Self) -> Int;
-  fn less(Self, Self) -> Bool;
+  fn add(Self, Self) -> int;
+  fn less(Self, Self) -> bool;
 }
 
-impl Arith for Int {
-  fn add(self: Int, other: Int) -> Int {
+impl Arith for int {
+  fn add(self: int, other: int) -> int {
       int_add(self, other)
   }
-  fn less(self: Int, other: Int) -> Bool {
+  fn less(self: int, other: int) -> bool {
       int_less(self, other)
   }
 }
 
 trait ToString {
-  fn to_string(Self) -> String;
+  fn to_string(Self) -> string;
 }
 
-impl ToString for Int {
-  fn to_string(self: Int) -> String {
+impl ToString for int {
+  fn to_string(self: int) -> string {
       int_to_string(self)
   }
 }
 
-impl ToString for Bool {
-  fn to_string(self: Bool) -> String {
+impl ToString for bool {
+  fn to_string(self: bool) -> string {
       bool_to_string(self)
   }
 }
 
 trait Output {
-  fn output(Self) -> Unit;
+  fn output(Self) -> unit;
 }
 
-impl Output for Int {
-  fn output(self: Int) -> Unit {
+impl Output for int {
+  fn output(self: int) -> unit {
       string_println(to_string(self))
   }
 }
 
-impl Output for Bool {
-  fn output(self: Bool) -> Unit {
+impl Output for bool {
+  fn output(self: bool) -> unit {
       string_println(to_string(self))
   }
 }

--- a/crates/compiler/src/tests/examples/002_overloading.src.core
+++ b/crates/compiler/src/tests/examples/002_overloading.src.core
@@ -1,39 +1,39 @@
-fn impl_Arith_Int_add(self/0: Int, other/1: Int) -> Int {
+fn impl_Arith_int_add(self/0: int, other/1: int) -> int {
   int_add(self/0, other/1)
 }
 
-fn impl_Arith_Int_less(self/2: Int, other/3: Int) -> Bool {
+fn impl_Arith_int_less(self/2: int, other/3: int) -> bool {
   int_less(self/2, other/3)
 }
 
-fn impl_ToString_Int_to_string(self/4: Int) -> String {
+fn impl_ToString_int_to_string(self/4: int) -> string {
   int_to_string(self/4)
 }
 
-fn impl_ToString_Bool_to_string(self/5: Bool) -> String {
+fn impl_ToString_bool_to_string(self/5: bool) -> string {
   bool_to_string(self/5)
 }
 
-fn impl_Output_Int_output(self/6: Int) -> Unit {
-  string_println(impl_ToString_Int_to_string(self/6))
+fn impl_Output_int_output(self/6: int) -> unit {
+  string_println(impl_ToString_int_to_string(self/6))
 }
 
-fn impl_Output_Bool_output(self/7: Bool) -> Unit {
-  string_println(impl_ToString_Bool_to_string(self/7))
+fn impl_Output_bool_output(self/7: bool) -> unit {
+  string_println(impl_ToString_bool_to_string(self/7))
 }
 
 fn id(x/8: T) -> T {
   x/8
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let a/9 = id(1) in
   let b/10 = id(2) in
-  let c/11 = impl_Arith_Int_add(a/9, b/10) in
-  let mtmp0 = impl_Output_Int_output(c/11) in
+  let c/11 = impl_Arith_int_add(a/9, b/10) in
+  let mtmp0 = impl_Output_int_output(c/11) in
   let a/12 = id(3) in
   let b/13 = id(4) in
-  let c/14 = impl_Arith_Int_less(a/12, b/13) in
-  let mtmp1 = impl_Output_Bool_output(c/14) in
+  let c/14 = impl_Arith_int_less(a/12, b/13) in
+  let mtmp1 = impl_Output_bool_output(c/14) in
   ()
 }

--- a/crates/compiler/src/tests/examples/002_overloading.src.cst
+++ b/crates/compiler/src/tests/examples/002_overloading.src.cst
@@ -24,7 +24,7 @@ FILE@0..1028
         Arrow@37..39 "->"
         Whitespace@39..40 " "
         TYPE_INT@40..43
-          IntKeyword@40..43 "Int"
+          IntKeyword@40..43 "int"
       Semi@43..44 ";"
       Whitespace@44..49 "\n    "
       TRAIT_METHOD_SIG@49..76
@@ -44,7 +44,7 @@ FILE@0..1028
         Arrow@69..71 "->"
         Whitespace@71..72 " "
         TYPE_BOOL@72..76
-          BoolKeyword@72..76 "Bool"
+          BoolKeyword@72..76 "bool"
       Semi@76..77 ";"
       Whitespace@77..78 "\n"
       RBrace@78..79 "}"
@@ -57,7 +57,7 @@ FILE@0..1028
     ForKeyword@92..95 "for"
     Whitespace@95..96 " "
     TYPE_INT@96..100
-      IntKeyword@96..99 "Int"
+      IntKeyword@96..99 "int"
       Whitespace@99..100 " "
     LBrace@100..101 "{"
     Whitespace@101..106 "\n    "
@@ -72,7 +72,7 @@ FILE@0..1028
           Colon@117..118 ":"
           Whitespace@118..119 " "
           TYPE_INT@119..122
-            IntKeyword@119..122 "Int"
+            IntKeyword@119..122 "int"
           Comma@122..123 ","
           Whitespace@123..124 " "
         PARAM@124..134
@@ -80,13 +80,13 @@ FILE@0..1028
           Colon@129..130 ":"
           Whitespace@130..131 " "
           TYPE_INT@131..134
-            IntKeyword@131..134 "Int"
+            IntKeyword@131..134 "int"
         RParen@134..135 ")"
         Whitespace@135..136 " "
       Arrow@136..138 "->"
       Whitespace@138..139 " "
       TYPE_INT@139..143
-        IntKeyword@139..142 "Int"
+        IntKeyword@139..142 "int"
         Whitespace@142..143 " "
       BLOCK@143..185
         LBrace@143..144 "{"
@@ -119,7 +119,7 @@ FILE@0..1028
           Colon@197..198 ":"
           Whitespace@198..199 " "
           TYPE_INT@199..202
-            IntKeyword@199..202 "Int"
+            IntKeyword@199..202 "int"
           Comma@202..203 ","
           Whitespace@203..204 " "
         PARAM@204..214
@@ -127,13 +127,13 @@ FILE@0..1028
           Colon@209..210 ":"
           Whitespace@210..211 " "
           TYPE_INT@211..214
-            IntKeyword@211..214 "Int"
+            IntKeyword@211..214 "int"
         RParen@214..215 ")"
         Whitespace@215..216 " "
       Arrow@216..218 "->"
       Whitespace@218..219 " "
       TYPE_BOOL@219..224
-        BoolKeyword@219..223 "Bool"
+        BoolKeyword@219..223 "bool"
         Whitespace@223..224 " "
       BLOCK@224..262
         LBrace@224..225 "{"
@@ -178,7 +178,7 @@ FILE@0..1028
         Arrow@305..307 "->"
         Whitespace@307..308 " "
         TYPE_STRING@308..314
-          StringKeyword@308..314 "String"
+          StringKeyword@308..314 "string"
       Semi@314..315 ";"
       Whitespace@315..316 "\n"
       RBrace@316..317 "}"
@@ -191,7 +191,7 @@ FILE@0..1028
     ForKeyword@333..336 "for"
     Whitespace@336..337 " "
     TYPE_INT@337..341
-      IntKeyword@337..340 "Int"
+      IntKeyword@337..340 "int"
       Whitespace@340..341 " "
     LBrace@341..342 "{"
     Whitespace@342..347 "\n    "
@@ -206,13 +206,13 @@ FILE@0..1028
           Colon@364..365 ":"
           Whitespace@365..366 " "
           TYPE_INT@366..369
-            IntKeyword@366..369 "Int"
+            IntKeyword@366..369 "int"
         RParen@369..370 ")"
         Whitespace@370..371 " "
       Arrow@371..373 "->"
       Whitespace@373..374 " "
       TYPE_STRING@374..381
-        StringKeyword@374..380 "String"
+        StringKeyword@374..380 "string"
         Whitespace@380..381 " "
       BLOCK@381..417
         LBrace@381..382 "{"
@@ -239,7 +239,7 @@ FILE@0..1028
     ForKeyword@434..437 "for"
     Whitespace@437..438 " "
     TYPE_BOOL@438..443
-      BoolKeyword@438..442 "Bool"
+      BoolKeyword@438..442 "bool"
       Whitespace@442..443 " "
     LBrace@443..444 "{"
     Whitespace@444..449 "\n    "
@@ -254,13 +254,13 @@ FILE@0..1028
           Colon@466..467 ":"
           Whitespace@467..468 " "
           TYPE_BOOL@468..472
-            BoolKeyword@468..472 "Bool"
+            BoolKeyword@468..472 "bool"
         RParen@472..473 ")"
         Whitespace@473..474 " "
       Arrow@474..476 "->"
       Whitespace@476..477 " "
       TYPE_STRING@477..484
-        StringKeyword@477..483 "String"
+        StringKeyword@477..483 "string"
         Whitespace@483..484 " "
       BLOCK@484..521
         LBrace@484..485 "{"
@@ -300,7 +300,7 @@ FILE@0..1028
         Arrow@559..561 "->"
         Whitespace@561..562 " "
         TYPE_UNIT@562..566
-          UnitKeyword@562..566 "Unit"
+          UnitKeyword@562..566 "unit"
       Semi@566..567 ";"
       Whitespace@567..568 "\n"
       RBrace@568..569 "}"
@@ -313,7 +313,7 @@ FILE@0..1028
     ForKeyword@583..586 "for"
     Whitespace@586..587 " "
     TYPE_INT@587..591
-      IntKeyword@587..590 "Int"
+      IntKeyword@587..590 "int"
       Whitespace@590..591 " "
     LBrace@591..592 "{"
     Whitespace@592..597 "\n    "
@@ -328,13 +328,13 @@ FILE@0..1028
           Colon@611..612 ":"
           Whitespace@612..613 " "
           TYPE_INT@613..616
-            IntKeyword@613..616 "Int"
+            IntKeyword@613..616 "int"
         RParen@616..617 ")"
         Whitespace@617..618 " "
       Arrow@618..620 "->"
       Whitespace@620..621 " "
       TYPE_UNIT@621..626
-        UnitKeyword@621..625 "Unit"
+        UnitKeyword@621..625 "unit"
         Whitespace@625..626 " "
       BLOCK@626..674
         LBrace@626..627 "{"
@@ -368,7 +368,7 @@ FILE@0..1028
     ForKeyword@689..692 "for"
     Whitespace@692..693 " "
     TYPE_BOOL@693..698
-      BoolKeyword@693..697 "Bool"
+      BoolKeyword@693..697 "bool"
       Whitespace@697..698 " "
     LBrace@698..699 "{"
     Whitespace@699..704 "\n    "
@@ -383,13 +383,13 @@ FILE@0..1028
           Colon@718..719 ":"
           Whitespace@719..720 " "
           TYPE_BOOL@720..724
-            BoolKeyword@720..724 "Bool"
+            BoolKeyword@720..724 "bool"
         RParen@724..725 ")"
         Whitespace@725..726 " "
       Arrow@726..728 "->"
       Whitespace@728..729 " "
       TYPE_UNIT@729..734
-        UnitKeyword@729..733 "Unit"
+        UnitKeyword@729..733 "unit"
         Whitespace@733..734 " "
       BLOCK@734..782
         LBrace@734..735 "{"

--- a/crates/compiler/src/tests/examples/002_overloading.src.gom
+++ b/crates/compiler/src/tests/examples/002_overloading.src.gom
@@ -51,59 +51,59 @@ func missing(s string) struct{} {
     return struct{}{}
 }
 
-func impl_Arith_Int_add(self__0 int, other__1 int) int {
+func impl_Arith_int_add(self__0 int, other__1 int) int {
     var ret4 int
     ret4 = int_add(self__0, other__1)
     return ret4
 }
 
-func impl_Arith_Int_less(self__2 int, other__3 int) bool {
+func impl_Arith_int_less(self__2 int, other__3 int) bool {
     var ret5 bool
     ret5 = int_less(self__2, other__3)
     return ret5
 }
 
-func impl_ToString_Int_to_string(self__4 int) string {
+func impl_ToString_int_to_string(self__4 int) string {
     var ret6 string
     ret6 = int_to_string(self__4)
     return ret6
 }
 
-func impl_ToString_Bool_to_string(self__5 bool) string {
+func impl_ToString_bool_to_string(self__5 bool) string {
     var ret7 string
     ret7 = bool_to_string(self__5)
     return ret7
 }
 
-func impl_Output_Int_output(self__6 int) struct{} {
+func impl_Output_int_output(self__6 int) struct{} {
     var ret8 struct{}
-    var t2 string = impl_ToString_Int_to_string(self__6)
+    var t2 string = impl_ToString_int_to_string(self__6)
     ret8 = string_println(t2)
     return ret8
 }
 
-func impl_Output_Bool_output(self__7 bool) struct{} {
+func impl_Output_bool_output(self__7 bool) struct{} {
     var ret9 struct{}
-    var t3 string = impl_ToString_Bool_to_string(self__7)
+    var t3 string = impl_ToString_bool_to_string(self__7)
     ret9 = string_println(t3)
     return ret9
 }
 
 func main0() struct{} {
     var ret10 struct{}
-    var a__9 int = id__T_Int(1)
-    var b__10 int = id__T_Int(2)
-    var c__11 int = impl_Arith_Int_add(a__9, b__10)
-    impl_Output_Int_output(c__11)
-    var a__12 int = id__T_Int(3)
-    var b__13 int = id__T_Int(4)
-    var c__14 bool = impl_Arith_Int_less(a__12, b__13)
-    impl_Output_Bool_output(c__14)
+    var a__9 int = id__T_int(1)
+    var b__10 int = id__T_int(2)
+    var c__11 int = impl_Arith_int_add(a__9, b__10)
+    impl_Output_int_output(c__11)
+    var a__12 int = id__T_int(3)
+    var b__13 int = id__T_int(4)
+    var c__14 bool = impl_Arith_int_less(a__12, b__13)
+    impl_Output_bool_output(c__14)
     ret10 = struct{}{}
     return ret10
 }
 
-func id__T_Int(x__8 int) int {
+func id__T_int(x__8 int) int {
     var ret11 int
     ret11 = x__8
     return ret11

--- a/crates/compiler/src/tests/examples/002_overloading.src.mono
+++ b/crates/compiler/src/tests/examples/002_overloading.src.mono
@@ -1,39 +1,39 @@
-fn impl_Arith_Int_add(self/0: Int, other/1: Int) -> Int {
+fn impl_Arith_int_add(self/0: int, other/1: int) -> int {
   int_add(self/0, other/1)
 }
 
-fn impl_Arith_Int_less(self/2: Int, other/3: Int) -> Bool {
+fn impl_Arith_int_less(self/2: int, other/3: int) -> bool {
   int_less(self/2, other/3)
 }
 
-fn impl_ToString_Int_to_string(self/4: Int) -> String {
+fn impl_ToString_int_to_string(self/4: int) -> string {
   int_to_string(self/4)
 }
 
-fn impl_ToString_Bool_to_string(self/5: Bool) -> String {
+fn impl_ToString_bool_to_string(self/5: bool) -> string {
   bool_to_string(self/5)
 }
 
-fn impl_Output_Int_output(self/6: Int) -> Unit {
-  string_println(impl_ToString_Int_to_string(self/6))
+fn impl_Output_int_output(self/6: int) -> unit {
+  string_println(impl_ToString_int_to_string(self/6))
 }
 
-fn impl_Output_Bool_output(self/7: Bool) -> Unit {
-  string_println(impl_ToString_Bool_to_string(self/7))
+fn impl_Output_bool_output(self/7: bool) -> unit {
+  string_println(impl_ToString_bool_to_string(self/7))
 }
 
-fn main() -> Unit {
-  let a/9 = id__T_Int(1) in
-  let b/10 = id__T_Int(2) in
-  let c/11 = impl_Arith_Int_add(a/9, b/10) in
-  let mtmp0 = impl_Output_Int_output(c/11) in
-  let a/12 = id__T_Int(3) in
-  let b/13 = id__T_Int(4) in
-  let c/14 = impl_Arith_Int_less(a/12, b/13) in
-  let mtmp1 = impl_Output_Bool_output(c/14) in
+fn main() -> unit {
+  let a/9 = id__T_int(1) in
+  let b/10 = id__T_int(2) in
+  let c/11 = impl_Arith_int_add(a/9, b/10) in
+  let mtmp0 = impl_Output_int_output(c/11) in
+  let a/12 = id__T_int(3) in
+  let b/13 = id__T_int(4) in
+  let c/14 = impl_Arith_int_less(a/12, b/13) in
+  let mtmp1 = impl_Output_bool_output(c/14) in
   ()
 }
 
-fn id__T_Int(x/8: Int) -> Int {
+fn id__T_int(x/8: int) -> int {
   x/8
 }

--- a/crates/compiler/src/tests/examples/002_overloading.src.tast
+++ b/crates/compiler/src/tests/examples/002_overloading.src.tast
@@ -1,33 +1,33 @@
-impl Arith for Int{
-  fn add(self/0: Int, other/1: Int) -> Int {
-    int_add((self/0 : Int), (other/1 : Int))
+impl Arith for int{
+  fn add(self/0: int, other/1: int) -> int {
+    int_add((self/0 : int), (other/1 : int))
   }
-  fn less(self/2: Int, other/3: Int) -> Bool {
-    int_less((self/2 : Int), (other/3 : Int))
-  }
-}
-
-impl ToString for Int{
-  fn to_string(self/4: Int) -> String {
-    int_to_string((self/4 : Int))
+  fn less(self/2: int, other/3: int) -> bool {
+    int_less((self/2 : int), (other/3 : int))
   }
 }
 
-impl ToString for Bool{
-  fn to_string(self/5: Bool) -> String {
-    bool_to_string((self/5 : Bool))
+impl ToString for int{
+  fn to_string(self/4: int) -> string {
+    int_to_string((self/4 : int))
   }
 }
 
-impl Output for Int{
-  fn output(self/6: Int) -> Unit {
-    string_println(to_string((self/6 : Int)))
+impl ToString for bool{
+  fn to_string(self/5: bool) -> string {
+    bool_to_string((self/5 : bool))
   }
 }
 
-impl Output for Bool{
-  fn output(self/7: Bool) -> Unit {
-    string_println(to_string((self/7 : Bool)))
+impl Output for int{
+  fn output(self/6: int) -> unit {
+    string_println(to_string((self/6 : int)))
+  }
+}
+
+impl Output for bool{
+  fn output(self/7: bool) -> unit {
+    string_println(to_string((self/7 : bool)))
   }
 }
 
@@ -35,14 +35,14 @@ fn id(x/8: T) -> T {
   (x/8 : T)
 }
 
-fn main() -> Unit {
-  let a/9: Int = id(1) in
-  let b/10: Int = id(2) in
-  let c/11: Int = add((a/9 : Int), (b/10 : Int)) in
-  let _ : Unit = output((c/11 : Int)) in
-  let a/12: Int = id(3) in
-  let b/13: Int = id(4) in
-  let c/14: Bool = less((a/12 : Int), (b/13 : Int)) in
-  let _ : Unit = output((c/14 : Bool)) in
+fn main() -> unit {
+  let a/9: int = id(1) in
+  let b/10: int = id(2) in
+  let c/11: int = add((a/9 : int), (b/10 : int)) in
+  let _ : unit = output((c/11 : int)) in
+  let a/12: int = id(3) in
+  let b/13: int = id(4) in
+  let c/14: bool = less((a/12 : int), (b/13 : int)) in
+  let _ : unit = output((c/14 : bool)) in
   ()
 }

--- a/crates/compiler/src/tests/examples/003_fib.src
+++ b/crates/compiler/src/tests/examples/003_fib.src
@@ -1,4 +1,4 @@
-fn fib(x: Int) -> Int {
+fn fib(x: int) -> int {
   match int_less(x, 2) {
     false => int_add(fib(int_sub(x, 1)), fib(int_sub(x, 2))),
     true => 1,

--- a/crates/compiler/src/tests/examples/003_fib.src.anf
+++ b/crates/compiler/src/tests/examples/003_fib.src.anf
@@ -1,4 +1,4 @@
-fn fib(x/0: Int) -> Int {
+fn fib(x/0: int) -> int {
   let mtmp0 = int_less(x/0, 2) in
   match mtmp0 {
     true => {
@@ -14,7 +14,7 @@ fn fib(x/0: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   let t6 = fib(10) in
   let t5 = int_to_string(t6) in
   string_print(t5)

--- a/crates/compiler/src/tests/examples/003_fib.src.ast
+++ b/crates/compiler/src/tests/examples/003_fib.src.ast
@@ -1,4 +1,4 @@
-fn fib(x: Int) -> Int {
+fn fib(x: int) -> int {
     match int_less(x, 2) {
         false => int_add(fib(int_sub(x, 1)), fib(int_sub(x, 2))),
         true => 1,

--- a/crates/compiler/src/tests/examples/003_fib.src.core
+++ b/crates/compiler/src/tests/examples/003_fib.src.core
@@ -1,4 +1,4 @@
-fn fib(x/0: Int) -> Int {
+fn fib(x/0: int) -> int {
   let mtmp0 = int_less(x/0, 2) in
   match mtmp0 {
     true => {
@@ -10,6 +10,6 @@ fn fib(x/0: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   string_print(int_to_string(fib(10)))
 }

--- a/crates/compiler/src/tests/examples/003_fib.src.cst
+++ b/crates/compiler/src/tests/examples/003_fib.src.cst
@@ -10,13 +10,13 @@ FILE@0..188
         Colon@8..9 ":"
         Whitespace@9..10 " "
         TYPE_INT@10..13
-          IntKeyword@10..13 "Int"
+          IntKeyword@10..13 "int"
       RParen@13..14 ")"
       Whitespace@14..15 " "
     Arrow@15..17 "->"
     Whitespace@17..18 " "
     TYPE_INT@18..22
-      IntKeyword@18..21 "Int"
+      IntKeyword@18..21 "int"
       Whitespace@21..22 " "
     BLOCK@22..133
       LBrace@22..23 "{"

--- a/crates/compiler/src/tests/examples/003_fib.src.mono
+++ b/crates/compiler/src/tests/examples/003_fib.src.mono
@@ -1,4 +1,4 @@
-fn fib(x/0: Int) -> Int {
+fn fib(x/0: int) -> int {
   let mtmp0 = int_less(x/0, 2) in
   match mtmp0 {
     true => {
@@ -10,6 +10,6 @@ fn fib(x/0: Int) -> Int {
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   string_print(int_to_string(fib(10)))
 }

--- a/crates/compiler/src/tests/examples/003_fib.src.tast
+++ b/crates/compiler/src/tests/examples/003_fib.src.tast
@@ -1,10 +1,10 @@
-fn fib(x/0: Int) -> Int {
-  match int_less((x/0 : Int), 2) {
-      false => int_add(fib(int_sub((x/0 : Int), 1)), fib(int_sub((x/0 : Int), 2))),
+fn fib(x/0: int) -> int {
+  match int_less((x/0 : int), 2) {
+      false => int_add(fib(int_sub((x/0 : int), 1)), fib(int_sub((x/0 : int), 2))),
       true => 1,
   }
 }
 
-fn main() -> Unit {
+fn main() -> unit {
   string_print(int_to_string(fib(10)))
 }

--- a/crates/compiler/src/tests/query_test.rs
+++ b/crates/compiler/src/tests/query_test.rs
@@ -21,17 +21,17 @@ fn main() {
 "#;
 
     check(src, 3, 8,expect![[r#"
-        "Int"
+        "int"
     "#]],);
     check(src, 3, 9,expect![[r#"
-        "Int"
+        "int"
     "#]],);
     check(src, 3, 10,expect![[r#"
         "<None>"
     "#]],);
 
     check(src, 4, 8, expect![[r#"
-        "(Bool, Int)"
+        "(bool, int)"
     "#]]);
 
     check(src, 5, 8, expect![[r#"

--- a/crates/compiler/src/tests/struct_type_test.rs
+++ b/crates/compiler/src/tests/struct_type_test.rs
@@ -19,17 +19,17 @@ fn typecheck(src: &str) -> (tast::File, Env) {
 fn collects_struct_definitions() {
     let src = r#"
 struct Point {
-    x: Int,
-    y: Int,
+    x: int,
+    y: int,
 }
 
 struct Wrapper[T] {
     value: T,
 }
 
-fn consume_point(p: Point) -> Unit { () }
+fn consume_point(p: Point) -> unit { () }
 
-fn consume_wrapper[T](value: Wrapper[T]) -> Unit { () }
+fn consume_wrapper[T](value: Wrapper[T]) -> unit { () }
 "#;
 
     let (_tast, env) = typecheck(src);
@@ -83,8 +83,8 @@ fn consume_wrapper[T](value: Wrapper[T]) -> Unit { () }
 fn enum_variants_record_struct_types() {
     let src = r#"
 struct Point {
-    x: Int,
-    y: Int,
+    x: int,
+    y: int,
 }
 
 struct Wrapper[U] {
@@ -141,7 +141,7 @@ enum Shape[T] {
 fn structs_and_enums_can_reference_each_other() {
     let src = r#"
 struct Node {
-    value: Int,
+    value: int,
     next: List,
 }
 
@@ -192,7 +192,7 @@ struct Wrapper[T] {
     value: T,
 }
 
-fn bad(value: Wrapper[Int, Int]) -> Unit { () }
+fn bad(value: Wrapper[int, int]) -> unit { () }
 "#;
 
     let _ = typecheck(src);
@@ -202,7 +202,7 @@ fn bad(value: Wrapper[Int, Int]) -> Unit { () }
 #[should_panic(expected = "Unknown type constructor Undefined")]
 fn unknown_type_constructor_panics() {
     let src = r#"
-fn bad(p: Undefined) -> Unit { () }
+fn bad(p: Undefined) -> unit { () }
 "#;
 
     let _ = typecheck(src);
@@ -216,7 +216,7 @@ struct Wrapper[T] {
     value: T,
 }
 
-fn bad[T](value: Wrapper[U]) -> Unit { () }
+fn bad[T](value: Wrapper[U]) -> unit { () }
 "#;
 
     let _ = typecheck(src);
@@ -231,7 +231,7 @@ struct Wrapper[T] {
 }
 
 enum Problem {
-    Bad(Wrapper[Int, Int]),
+    Bad(Wrapper[int, int]),
 }
 "#;
 

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -171,16 +171,16 @@ pub enum TokenKind {
     #[token("_")]
     WildcardKeyword,
 
-    #[token("Unit")]
+    #[token("unit")]
     UnitKeyword,
 
-    #[token("Bool")]
+    #[token("bool")]
     BoolKeyword,
 
-    #[token("Int")]
+    #[token("int")]
     IntKeyword,
 
-    #[token("String")]
+    #[token("string")]
     StringKeyword,
 
     #[regex("[a-z][A-Za-z_0-9]*")]
@@ -246,10 +246,10 @@ impl std::fmt::Display for TokenKind {
             Self::TrueKeyword => "true",
             Self::FalseKeyword => "false",
             Self::WildcardKeyword => "_",
-            Self::UnitKeyword => "Unit",
-            Self::BoolKeyword => "Bool",
-            Self::IntKeyword => "Int",
-            Self::StringKeyword => "String",
+            Self::UnitKeyword => "unit",
+            Self::BoolKeyword => "bool",
+            Self::IntKeyword => "int",
+            Self::StringKeyword => "string",
             Self::Lident => "lident",
             Self::Uident => "uident",
             Self::Int => "int",

--- a/crates/parser/src/file.rs
+++ b/crates/parser/src/file.rs
@@ -84,8 +84,8 @@ fn trait_def(p: &mut Parser) {
 }
 
 // {
-//   fn foo(x: Int) -> Int;
-//   fn bar(x: Int) -> Int;
+//   fn foo(x: int) -> int;
+//   fn bar(x: int) -> int;
 // }
 
 fn trait_method_list(p: &mut Parser) {

--- a/crates/parser/tests/structs.rs
+++ b/crates/parser/tests/structs.rs
@@ -12,8 +12,8 @@ fn check(input: &str, expect: Expect) {
 fn struct_with_fields() {
     check(
         r#"struct Point {
-    x: Int,
-    y: Int,
+    x: int,
+    y: int,
 }
 "#,
         expect![[r#"
@@ -31,7 +31,7 @@ fn struct_with_fields() {
                     Colon@20..21 ":"
                     Whitespace@21..22 " "
                     TYPE_INT@22..25
-                      IntKeyword@22..25 "Int"
+                      IntKeyword@22..25 "int"
                   Comma@25..26 ","
                   Whitespace@26..31 "\n    "
                   STRUCT_FIELD@31..37
@@ -39,7 +39,7 @@ fn struct_with_fields() {
                     Colon@32..33 ":"
                     Whitespace@33..34 " "
                     TYPE_INT@34..37
-                      IntKeyword@34..37 "Int"
+                      IntKeyword@34..37 "int"
                   Comma@37..38 ","
                   Whitespace@38..39 "\n"
                   RBrace@39..40 "}"

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -37,7 +37,7 @@ function App() {
         keywords: ['fn', 'let', 'in'],
         tokenizer: {
           root: [
-            [/\b(fn|enum|trait|impl|for|match|if|else|let|in|return|true|false|Unit|Bool|Int)\b/, "keyword"],
+            [/\b(fn|enum|trait|impl|for|match|if|else|let|in|return|true|false|unit|bool|int|string)\b/, "keyword"],
             [/\b[A-Z][a-zA-Z0-9_]*\b/, "type"],
             [/\b\d+\b/, "number"],
             [/[a-zA-Z_]\w*(?=\s*\()/, "function"],


### PR DESCRIPTION
## Summary
- lowercase builtin type keywords in the lexer and downstream printers/encoders
- update sample programs and expect snapshots to use the lowercase builtins
- align the web playground syntax highlighting with the new keyword casing

## Testing
- env UPDATE_EXPECT=1 cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cb8863cf0c832bb8cfd88246f311cc