### PR TITLE
refactor: split constructor representations

### DIFF
--- a/crates/compiler/src/anf.rs
+++ b/crates/compiler/src/anf.rs
@@ -99,11 +99,11 @@ fn core_imm_to_anf_imm(core_imm: core::Expr) -> ImmExpr {
         core::Expr::EInt { value, ty } => ImmExpr::ImmInt { value, ty },
         core::Expr::EString { value, ty } => ImmExpr::ImmString { value, ty },
         core::Expr::EConstr {
-            constructor,
+            constructor: Constructor::Enum(enum_constructor),
             args,
             ty,
-        } if constructor.enum_index().is_some() && args.is_empty() => ImmExpr::ImmTag {
-            index: constructor.enum_index().unwrap(),
+        } if args.is_empty() => ImmExpr::ImmTag {
+            index: enum_constructor.enum_index(),
             ty,
         },
         // Other core::Expr variants are not immediate and should not appear as match arm LHS patterns.
@@ -142,13 +142,13 @@ fn compile_match_arms_to_anf<'a>(
                 });
             }
             core::Expr::EConstr {
-                constructor,
+                constructor: Constructor::Enum(enum_constructor),
                 args,
                 ty,
-            } if constructor.enum_index().is_some() && args.is_empty() => {
+            } if args.is_empty() => {
                 // Nullary constructors are immediate
                 let anf_lhs = ImmExpr::ImmTag {
-                    index: constructor.enum_index().unwrap(),
+                    index: enum_constructor.enum_index(),
                     ty: ty.clone(),
                 };
                 let anf_body = anf(env, arm.body, Box::new(|c| AExpr::ACExpr { expr: c }));
@@ -158,13 +158,13 @@ fn compile_match_arms_to_anf<'a>(
                 });
             }
             core::Expr::EConstr {
-                constructor,
+                constructor: Constructor::Enum(enum_constructor),
                 args: _args,
                 ty,
-            } if constructor.enum_index().is_some() => {
+            } => {
                 // Patterns were already simplified in compile_match.rs. Do not duplicate field extraction here.
                 let anf_lhs = ImmExpr::ImmTag {
-                    index: constructor.enum_index().unwrap(),
+                    index: enum_constructor.enum_index(),
                     ty: ty.clone(),
                 };
                 let anf_body = anf(env, arm.body, Box::new(|c| AExpr::ACExpr { expr: c }));
@@ -211,33 +211,36 @@ fn anf<'a>(env: &'a Env, e: core::Expr, k: Box<dyn FnOnce(CExpr) -> AExpr + 'a>)
         }),
 
         core::Expr::EConstr {
+            constructor: Constructor::Enum(enum_constructor),
+            args,
+            ty: _,
+        } if args.is_empty() => {
+            // Nullary enum constructors are immediate tags
+            k(CExpr::CImm {
+                imm: ImmExpr::ImmTag {
+                    index: enum_constructor.enum_index(),
+                    ty: e_ty,
+                },
+            })
+        }
+        core::Expr::EConstr {
             constructor,
             args,
             ty: _,
         } => {
-            if args.is_empty() && constructor.enum_index().is_some() {
-                // Nullary enum constructors are immediate tags
-                k(CExpr::CImm {
-                    imm: ImmExpr::ImmTag {
-                        index: constructor.enum_index().unwrap(),
-                        ty: e_ty,
-                    },
-                })
-            } else {
-                let constructor = constructor.clone();
-                let ty_clone = e_ty.clone();
-                anf_list(
-                    env,
-                    &args,
-                    Box::new(move |args| {
-                        k(CExpr::EConstr {
-                            constructor: constructor.clone(),
-                            args,
-                            ty: ty_clone.clone(),
-                        })
-                    }),
-                )
-            }
+            let constructor = constructor.clone();
+            let ty_clone = e_ty.clone();
+            anf_list(
+                env,
+                &args,
+                Box::new(move |args| {
+                    k(CExpr::EConstr {
+                        constructor: constructor.clone(),
+                        args,
+                        ty: ty_clone.clone(),
+                    })
+                }),
+            )
         }
         core::Expr::ETuple { items, ty: _ } => anf_list(
             env,

--- a/crates/compiler/src/anf.rs
+++ b/crates/compiler/src/anf.rs
@@ -102,8 +102,8 @@ fn core_imm_to_anf_imm(core_imm: core::Expr) -> ImmExpr {
             constructor,
             args,
             ty,
-        } if constructor.kind.enum_index().is_some() && args.is_empty() => ImmExpr::ImmTag {
-            index: constructor.kind.enum_index().unwrap(),
+        } if constructor.enum_index().is_some() && args.is_empty() => ImmExpr::ImmTag {
+            index: constructor.enum_index().unwrap(),
             ty,
         },
         // Other core::Expr variants are not immediate and should not appear as match arm LHS patterns.
@@ -145,10 +145,10 @@ fn compile_match_arms_to_anf<'a>(
                 constructor,
                 args,
                 ty,
-            } if constructor.kind.enum_index().is_some() && args.is_empty() => {
+            } if constructor.enum_index().is_some() && args.is_empty() => {
                 // Nullary constructors are immediate
                 let anf_lhs = ImmExpr::ImmTag {
-                    index: constructor.kind.enum_index().unwrap(),
+                    index: constructor.enum_index().unwrap(),
                     ty: ty.clone(),
                 };
                 let anf_body = anf(env, arm.body, Box::new(|c| AExpr::ACExpr { expr: c }));
@@ -161,10 +161,10 @@ fn compile_match_arms_to_anf<'a>(
                 constructor,
                 args: _args,
                 ty,
-            } if constructor.kind.enum_index().is_some() => {
+            } if constructor.enum_index().is_some() => {
                 // Patterns were already simplified in compile_match.rs. Do not duplicate field extraction here.
                 let anf_lhs = ImmExpr::ImmTag {
-                    index: constructor.kind.enum_index().unwrap(),
+                    index: constructor.enum_index().unwrap(),
                     ty: ty.clone(),
                 };
                 let anf_body = anf(env, arm.body, Box::new(|c| AExpr::ACExpr { expr: c }));
@@ -215,11 +215,11 @@ fn anf<'a>(env: &'a Env, e: core::Expr, k: Box<dyn FnOnce(CExpr) -> AExpr + 'a>)
             args,
             ty: _,
         } => {
-            if args.is_empty() && constructor.kind.enum_index().is_some() {
+            if args.is_empty() && constructor.enum_index().is_some() {
                 // Nullary enum constructors are immediate tags
                 k(CExpr::CImm {
                     imm: ImmExpr::ImmTag {
-                        index: constructor.kind.enum_index().unwrap(),
+                        index: constructor.enum_index().unwrap(),
                         ty: e_ty,
                     },
                 })

--- a/crates/compiler/src/compile_match.rs
+++ b/crates/compiler/src/compile_match.rs
@@ -206,8 +206,9 @@ fn compile_constructor_cases(
             } = col.pat
             {
                 let idx = constructor
-                    .enum_index()
-                    .expect("expected enum constructor in compile_constructor_cases");
+                    .as_enum()
+                    .expect("expected enum constructor in compile_constructor_cases")
+                    .enum_index();
                 let mut cols = row.columns;
                 for (var, pat) in cases[idx].vars.iter().zip(args.into_iter()) {
                     cols.push(Column {

--- a/crates/compiler/src/env.rs
+++ b/crates/compiler/src/env.rs
@@ -3,7 +3,7 @@ use indexmap::{IndexMap, IndexSet};
 
 use crate::{
     core,
-    tast::{self, Constructor, ConstructorKind},
+    tast::{self, Constructor},
 };
 use std::cell::Cell;
 
@@ -154,13 +154,11 @@ impl Env {
                         }
                     };
 
-                    let constructor = Constructor {
-                        name: variant_name.clone(),
-                        kind: ConstructorKind::Enum {
-                            type_name: enum_name.clone(),
-                            index,
-                        },
-                    };
+                    let constructor = Constructor::Enum(tast::EnumConstructor {
+                        type_name: enum_name.clone(),
+                        variant: variant_name.clone(),
+                        index,
+                    });
                     return Some((constructor, ctor_ty));
                 }
             }
@@ -186,12 +184,9 @@ impl Env {
                 }
             };
 
-            let constructor = Constructor {
-                name: struct_def.name.clone(),
-                kind: ConstructorKind::Struct {
-                    type_name: struct_def.name.clone(),
-                },
-            };
+            let constructor = Constructor::Struct(tast::StructConstructor {
+                type_name: struct_def.name.clone(),
+            });
             return Some((constructor, ctor_ty));
         }
 

--- a/crates/compiler/src/mono.rs
+++ b/crates/compiler/src/mono.rs
@@ -1,6 +1,6 @@
 use super::core;
 use crate::env::{EnumDef, Env, StructDef};
-use crate::tast::{Constructor, ConstructorKind, Ty};
+use crate::tast::{self, Constructor, Ty};
 use ast::ast::Uident;
 use indexmap::{IndexMap, IndexSet};
 use std::collections::VecDeque;
@@ -27,20 +27,19 @@ pub fn mono(env: &mut Env, file: core::File) -> core::File {
     }
 
     fn update_constructor_type(constructor: &Constructor, new_ty: &Ty) -> Constructor {
-        match (&constructor.kind, new_ty) {
-            (ConstructorKind::Enum { index, .. }, Ty::TApp { name, .. }) => Constructor {
-                name: constructor.name.clone(),
-                kind: ConstructorKind::Enum {
+        match (constructor, new_ty) {
+            (Constructor::Enum(enum_constructor), Ty::TApp { name, .. }) => {
+                Constructor::Enum(tast::EnumConstructor {
                     type_name: name.clone(),
-                    index: *index,
-                },
-            },
-            (ConstructorKind::Struct { .. }, Ty::TApp { name, .. }) => Constructor {
-                name: name.clone(),
-                kind: ConstructorKind::Struct {
+                    variant: enum_constructor.variant.clone(),
+                    index: enum_constructor.index,
+                })
+            }
+            (Constructor::Struct(_), Ty::TApp { name, .. }) => {
+                Constructor::Struct(tast::StructConstructor {
                     type_name: name.clone(),
-                },
-            },
+                })
+            }
             _ => constructor.clone(),
         }
     }

--- a/crates/compiler/src/pprint/core_pprint.rs
+++ b/crates/compiler/src/pprint/core_pprint.rs
@@ -3,7 +3,7 @@ use pretty::RcDoc;
 use crate::{
     core::{Arm, Expr, File, Fn},
     env::Env,
-    tast::ConstructorKind,
+    tast::Constructor,
 };
 
 impl File {
@@ -82,9 +82,12 @@ impl Expr {
                 constructor,
                 args,
                 ty: _,
-            } => match &constructor.kind {
-                ConstructorKind::Enum { type_name, .. } => {
-                    let name_doc = RcDoc::text(format!("{}::{}", type_name.0, constructor.name.0));
+            } => match constructor {
+                Constructor::Enum(enum_constructor) => {
+                    let name_doc = RcDoc::text(format!(
+                        "{}::{}",
+                        enum_constructor.type_name.0, enum_constructor.variant.0
+                    ));
 
                     if args.is_empty() {
                         name_doc
@@ -100,10 +103,10 @@ impl Expr {
                             .append(RcDoc::text(")"))
                     }
                 }
-                ConstructorKind::Struct { type_name } => {
-                    let name_doc = RcDoc::text(constructor.name.0.clone());
+                Constructor::Struct(struct_constructor) => {
+                    let name_doc = RcDoc::text(struct_constructor.type_name.0.clone());
 
-                    if let Some(struct_def) = env.structs.get(type_name) {
+                    if let Some(struct_def) = env.structs.get(&struct_constructor.type_name) {
                         if struct_def.fields.is_empty() {
                             name_doc.append(RcDoc::space()).append(RcDoc::text("{}"))
                         } else if struct_def.fields.len() == args.len() {
@@ -243,19 +246,23 @@ impl Expr {
                 field_index,
                 ty: _,
             } => {
-                let accessor = match &constructor.kind {
-                    ConstructorKind::Enum { type_name, .. } => RcDoc::text(format!(
+                let accessor = match constructor {
+                    Constructor::Enum(enum_constructor) => RcDoc::text(format!(
                         "{}::{}._{}",
-                        type_name.0, constructor.name.0, field_index
+                        enum_constructor.type_name.0, enum_constructor.variant.0, field_index
                     )),
-                    ConstructorKind::Struct { type_name } => {
+                    Constructor::Struct(struct_constructor) => {
                         let field_name = env
                             .structs
-                            .get(type_name)
+                            .get(&struct_constructor.type_name)
                             .and_then(|def| def.fields.get(*field_index))
                             .map(|(fname, _)| fname.0.clone())
                             .unwrap_or_else(|| format!("_{}", field_index));
-                        RcDoc::text(format!("{}.{field}", type_name.0, field = field_name))
+                        RcDoc::text(format!(
+                            "{}.{field}",
+                            struct_constructor.type_name.0,
+                            field = field_name
+                        ))
                     }
                 };
 

--- a/crates/compiler/src/pprint/tast_pprint.rs
+++ b/crates/compiler/src/pprint/tast_pprint.rs
@@ -1,7 +1,7 @@
 use pretty::RcDoc;
 
 use crate::env::Env;
-use crate::tast::ConstructorKind;
+use crate::tast::Constructor;
 use crate::tast::Expr;
 use crate::tast::File;
 use crate::tast::Fn;
@@ -203,9 +203,12 @@ impl Expr {
                 constructor,
                 args,
                 ty: _,
-            } => match &constructor.kind {
-                ConstructorKind::Enum { type_name, .. } => {
-                    let name_doc = RcDoc::text(format!("{}::{}", type_name.0, constructor.name.0));
+            } => match constructor {
+                Constructor::Enum(enum_constructor) => {
+                    let name_doc = RcDoc::text(format!(
+                        "{}::{}",
+                        enum_constructor.type_name.0, enum_constructor.variant.0
+                    ));
 
                     if args.is_empty() {
                         name_doc
@@ -221,10 +224,10 @@ impl Expr {
                             .append(RcDoc::text(")"))
                     }
                 }
-                ConstructorKind::Struct { type_name } => {
-                    let name_doc = RcDoc::text(constructor.name.0.clone());
+                Constructor::Struct(struct_constructor) => {
+                    let name_doc = RcDoc::text(struct_constructor.type_name.0.clone());
 
-                    if let Some(struct_def) = env.structs.get(type_name) {
+                    if let Some(struct_def) = env.structs.get(&struct_constructor.type_name) {
                         if struct_def.fields.is_empty() {
                             name_doc.append(RcDoc::space()).append(RcDoc::text("{}"))
                         } else if struct_def.fields.len() == args.len() {
@@ -379,9 +382,12 @@ impl Pat {
                 constructor,
                 args,
                 ty: _,
-            } => match &constructor.kind {
-                ConstructorKind::Enum { type_name, .. } => {
-                    let name_doc = RcDoc::text(format!("{}::{}", type_name.0, constructor.name.0));
+            } => match constructor {
+                Constructor::Enum(enum_constructor) => {
+                    let name_doc = RcDoc::text(format!(
+                        "{}::{}",
+                        enum_constructor.type_name.0, enum_constructor.variant.0
+                    ));
 
                     if args.is_empty() {
                         name_doc
@@ -396,10 +402,10 @@ impl Pat {
                             .append(RcDoc::text(")"))
                     }
                 }
-                ConstructorKind::Struct { type_name } => {
-                    let name_doc = RcDoc::text(constructor.name.0.clone());
+                Constructor::Struct(struct_constructor) => {
+                    let name_doc = RcDoc::text(struct_constructor.type_name.0.clone());
 
-                    if let Some(struct_def) = env.structs.get(type_name) {
+                    if let Some(struct_def) = env.structs.get(&struct_constructor.type_name) {
                         if struct_def.fields.is_empty() {
                             name_doc.append(RcDoc::space()).append(RcDoc::text("{}"))
                         } else if struct_def.fields.len() == args.len() {

--- a/crates/compiler/src/tast.rs
+++ b/crates/compiler/src/tast.rs
@@ -29,36 +29,64 @@ pub struct Fn {
 }
 
 #[derive(Debug, Clone)]
-pub enum ConstructorKind {
-    Enum { type_name: Uident, index: usize },
-    Struct { type_name: Uident },
+pub struct EnumConstructor {
+    pub type_name: Uident,
+    pub variant: Uident,
+    pub index: usize,
 }
 
-impl ConstructorKind {
+#[derive(Debug, Clone)]
+pub struct StructConstructor {
+    pub type_name: Uident,
+}
+
+#[derive(Debug, Clone)]
+pub enum Constructor {
+    Enum(EnumConstructor),
+    Struct(StructConstructor),
+}
+
+impl Constructor {
+    pub fn name(&self) -> &Uident {
+        match self {
+            Constructor::Enum(constructor) => &constructor.variant,
+            Constructor::Struct(constructor) => &constructor.type_name,
+        }
+    }
+
     pub fn type_name(&self) -> &Uident {
         match self {
-            ConstructorKind::Enum { type_name, .. } | ConstructorKind::Struct { type_name } => {
-                type_name
-            }
+            Constructor::Enum(constructor) => &constructor.type_name,
+            Constructor::Struct(constructor) => &constructor.type_name,
         }
     }
 
     pub fn enum_index(&self) -> Option<usize> {
         match self {
-            ConstructorKind::Enum { index, .. } => Some(*index),
-            ConstructorKind::Struct { .. } => None,
+            Constructor::Enum(constructor) => Some(constructor.index),
+            Constructor::Struct(_) => None,
         }
     }
 
     pub fn is_struct(&self) -> bool {
-        matches!(self, ConstructorKind::Struct { .. })
+        matches!(self, Constructor::Struct(_))
     }
-}
 
-#[derive(Debug, Clone)]
-pub struct Constructor {
-    pub name: Uident,
-    pub kind: ConstructorKind,
+    pub fn as_enum(&self) -> Option<&EnumConstructor> {
+        if let Constructor::Enum(constructor) = self {
+            Some(constructor)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_struct(&self) -> Option<&StructConstructor> {
+        if let Constructor::Struct(constructor) = self {
+            Some(constructor)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]

--- a/crates/compiler/src/tast.rs
+++ b/crates/compiler/src/tast.rs
@@ -35,6 +35,12 @@ pub struct EnumConstructor {
     pub index: usize,
 }
 
+impl EnumConstructor {
+    pub fn enum_index(&self) -> usize {
+        self.index
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StructConstructor {
     pub type_name: Uident,
@@ -58,13 +64,6 @@ impl Constructor {
         match self {
             Constructor::Enum(constructor) => &constructor.type_name,
             Constructor::Struct(constructor) => &constructor.type_name,
-        }
-    }
-
-    pub fn enum_index(&self) -> Option<usize> {
-        match self {
-            Constructor::Enum(constructor) => Some(constructor.index),
-            Constructor::Struct(_) => None,
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the shared `ConstructorKind` enum with explicit enum/struct constructor types in the typed AST
- update environment lookup, type inference, pattern compilation, monomorphization, and pretty printers to use the new helpers
- adjust the Go backend and ANF lowering to handle the refactored constructors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68cc163234fc832b9a6706a9f464596a