### PR TITLE
fix: surface parser errors

### DIFF
--- a/crates/compiler/src/compile_match.rs
+++ b/crates/compiler/src/compile_match.rs
@@ -534,7 +534,7 @@ fn compile_int_case(env: &Env, rows: Vec<Row>, bvar: &Variable, ty: &Ty) -> core
                 Pat::PInt { value, ty: _ } => {
                     let entry = value_rows
                         .entry(value)
-                        .or_insert_with(|| fallback_rows.iter().cloned().collect::<Vec<_>>());
+                        .or_insert_with(|| fallback_rows.clone());
                     entry.push(row);
                 }
                 Pat::PWild { .. } => {
@@ -595,7 +595,7 @@ fn compile_string_case(env: &Env, rows: Vec<Row>, bvar: &Variable, ty: &Ty) -> c
                 Pat::PString { value, ty: _ } => {
                     let entry = value_rows
                         .entry(value)
-                        .or_insert_with(|| fallback_rows.iter().cloned().collect());
+                        .or_insert_with(|| fallback_rows.clone());
                     entry.push(row);
                 }
                 Pat::PWild { .. } => {

--- a/crates/compiler/src/query.rs
+++ b/crates/compiler/src/query.rs
@@ -5,6 +5,9 @@ use crate::{env::Env, tast};
 
 pub fn hover_type(src: &str, line: u32, col: u32) -> Option<String> {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return None;
+    }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap_or_else(|| panic!("failed to cast syntax tree"));
 

--- a/crates/compiler/src/tests/cases/017.src
+++ b/crates/compiler/src/tests/cases/017.src
@@ -22,7 +22,7 @@ impl ToString for (int, int) {
 
 fn main() {
     let x = 123 in
-    let _ string_println(to_string(x)) in
+    let _ = string_println(to_string(x)) in
 
     let x = true in
     let _ = string_println(to_string(x)) in

--- a/crates/compiler/src/tests/cases/017.src.cst
+++ b/crates/compiler/src/tests/cases/017.src.cst
@@ -1,4 +1,4 @@
-FILE@0..571
+FILE@0..573
   TRAIT@0..54
     TraitKeyword@0..5 "trait"
     Whitespace@5..6 " "
@@ -178,7 +178,7 @@ FILE@0..571
         Whitespace@352..353 "\n"
     RBrace@353..354 "}"
     Whitespace@354..356 "\n\n"
-  FN@356..571
+  FN@356..573
     FnKeyword@356..358 "fn"
     Whitespace@358..359 " "
     Lident@359..363 "main"
@@ -186,10 +186,10 @@ FILE@0..571
       LParen@363..364 "("
       RParen@364..365 ")"
       Whitespace@365..366 " "
-    BLOCK@366..571
+    BLOCK@366..573
       LBrace@366..367 "{"
       Whitespace@367..372 "\n    "
-      EXPR_LET@372..569
+      EXPR_LET@372..571
         LetKeyword@372..375 "let"
         Whitespace@375..376 " "
         PATTERN_VARIABLE@376..378
@@ -203,132 +203,134 @@ FILE@0..571
             Whitespace@383..384 " "
         InKeyword@384..386 "in"
         Whitespace@386..391 "\n    "
-        EXPR_LET_BODY@391..569
-          EXPR_LET@391..569
+        EXPR_LET_BODY@391..571
+          EXPR_LET@391..571
             LetKeyword@391..394 "let"
             Whitespace@394..395 " "
             PATTERN_WILDCARD@395..397
               WildcardKeyword@395..396 "_"
               Whitespace@396..397 " "
-            EXPR_LET_VALUE@397..426
-              EXPR_CALL@397..426
-                EXPR_LIDENT@397..411
-                  Lident@397..411 "string_println"
-                ARG_LIST@411..426
-                  LParen@411..412 "("
-                  ARG@412..424
-                    EXPR_CALL@412..424
-                      EXPR_LIDENT@412..421
-                        Lident@412..421 "to_string"
-                      ARG_LIST@421..424
-                        LParen@421..422 "("
-                        ARG@422..423
-                          EXPR_LIDENT@422..423
-                            Lident@422..423 "x"
-                        RParen@423..424 ")"
-                  RParen@424..425 ")"
-                  Whitespace@425..426 " "
-            InKeyword@426..428 "in"
-            Whitespace@428..434 "\n\n    "
-            EXPR_LET_BODY@434..569
-              EXPR_LET@434..569
-                LetKeyword@434..437 "let"
-                Whitespace@437..438 " "
-                PATTERN_VARIABLE@438..440
-                  Lident@438..439 "x"
-                  Whitespace@439..440 " "
-                Eq@440..441 "="
-                Whitespace@441..442 " "
-                EXPR_LET_VALUE@442..447
-                  EXPR_BOOL@442..447
-                    TrueKeyword@442..446 "true"
-                    Whitespace@446..447 " "
-                InKeyword@447..449 "in"
-                Whitespace@449..454 "\n    "
-                EXPR_LET_BODY@454..569
-                  EXPR_LET@454..569
-                    LetKeyword@454..457 "let"
-                    Whitespace@457..458 " "
-                    PATTERN_WILDCARD@458..460
-                      WildcardKeyword@458..459 "_"
-                      Whitespace@459..460 " "
-                    Eq@460..461 "="
-                    Whitespace@461..462 " "
-                    EXPR_LET_VALUE@462..491
-                      EXPR_CALL@462..491
-                        EXPR_LIDENT@462..476
-                          Lident@462..476 "string_println"
-                        ARG_LIST@476..491
-                          LParen@476..477 "("
-                          ARG@477..489
-                            EXPR_CALL@477..489
-                              EXPR_LIDENT@477..486
-                                Lident@477..486 "to_string"
-                              ARG_LIST@486..489
-                                LParen@486..487 "("
-                                ARG@487..488
-                                  EXPR_LIDENT@487..488
-                                    Lident@487..488 "x"
-                                RParen@488..489 ")"
-                          RParen@489..490 ")"
-                          Whitespace@490..491 " "
-                    InKeyword@491..493 "in"
-                    Whitespace@493..499 "\n\n    "
-                    EXPR_LET_BODY@499..569
-                      EXPR_LET@499..569
-                        LetKeyword@499..502 "let"
-                        Whitespace@502..503 " "
-                        PATTERN_VARIABLE@503..505
-                          Lident@503..504 "x"
-                          Whitespace@504..505 " "
-                        Eq@505..506 "="
-                        Whitespace@506..507 " "
-                        EXPR_LET_VALUE@507..514
-                          EXPR_TUPLE@507..514
-                            LParen@507..508 "("
-                            EXPR_INT@508..509
-                              Int@508..509 "3"
-                            Comma@509..510 ","
-                            Whitespace@510..511 " "
-                            EXPR_INT@511..512
-                              Int@511..512 "4"
-                            RParen@512..513 ")"
-                            Whitespace@513..514 " "
-                        InKeyword@514..516 "in"
-                        Whitespace@516..521 "\n    "
-                        EXPR_LET_BODY@521..569
-                          EXPR_LET@521..569
-                            LetKeyword@521..524 "let"
-                            Whitespace@524..525 " "
-                            PATTERN_WILDCARD@525..527
-                              WildcardKeyword@525..526 "_"
-                              Whitespace@526..527 " "
-                            Eq@527..528 "="
-                            Whitespace@528..529 " "
-                            EXPR_LET_VALUE@529..558
-                              EXPR_CALL@529..558
-                                EXPR_LIDENT@529..543
-                                  Lident@529..543 "string_println"
-                                ARG_LIST@543..558
-                                  LParen@543..544 "("
-                                  ARG@544..556
-                                    EXPR_CALL@544..556
-                                      EXPR_LIDENT@544..553
-                                        Lident@544..553 "to_string"
-                                      ARG_LIST@553..556
-                                        LParen@553..554 "("
-                                        ARG@554..555
-                                          EXPR_LIDENT@554..555
-                                            Lident@554..555 "x"
-                                        RParen@555..556 ")"
-                                  RParen@556..557 ")"
-                                  Whitespace@557..558 " "
-                            InKeyword@558..560 "in"
-                            Whitespace@560..566 "\n\n    "
-                            EXPR_LET_BODY@566..569
-                              EXPR_UNIT@566..569
-                                LParen@566..567 "("
-                                RParen@567..568 ")"
-                                Whitespace@568..569 "\n"
-      RBrace@569..570 "}"
-      Whitespace@570..571 "\n"
+            Eq@397..398 "="
+            Whitespace@398..399 " "
+            EXPR_LET_VALUE@399..428
+              EXPR_CALL@399..428
+                EXPR_LIDENT@399..413
+                  Lident@399..413 "string_println"
+                ARG_LIST@413..428
+                  LParen@413..414 "("
+                  ARG@414..426
+                    EXPR_CALL@414..426
+                      EXPR_LIDENT@414..423
+                        Lident@414..423 "to_string"
+                      ARG_LIST@423..426
+                        LParen@423..424 "("
+                        ARG@424..425
+                          EXPR_LIDENT@424..425
+                            Lident@424..425 "x"
+                        RParen@425..426 ")"
+                  RParen@426..427 ")"
+                  Whitespace@427..428 " "
+            InKeyword@428..430 "in"
+            Whitespace@430..436 "\n\n    "
+            EXPR_LET_BODY@436..571
+              EXPR_LET@436..571
+                LetKeyword@436..439 "let"
+                Whitespace@439..440 " "
+                PATTERN_VARIABLE@440..442
+                  Lident@440..441 "x"
+                  Whitespace@441..442 " "
+                Eq@442..443 "="
+                Whitespace@443..444 " "
+                EXPR_LET_VALUE@444..449
+                  EXPR_BOOL@444..449
+                    TrueKeyword@444..448 "true"
+                    Whitespace@448..449 " "
+                InKeyword@449..451 "in"
+                Whitespace@451..456 "\n    "
+                EXPR_LET_BODY@456..571
+                  EXPR_LET@456..571
+                    LetKeyword@456..459 "let"
+                    Whitespace@459..460 " "
+                    PATTERN_WILDCARD@460..462
+                      WildcardKeyword@460..461 "_"
+                      Whitespace@461..462 " "
+                    Eq@462..463 "="
+                    Whitespace@463..464 " "
+                    EXPR_LET_VALUE@464..493
+                      EXPR_CALL@464..493
+                        EXPR_LIDENT@464..478
+                          Lident@464..478 "string_println"
+                        ARG_LIST@478..493
+                          LParen@478..479 "("
+                          ARG@479..491
+                            EXPR_CALL@479..491
+                              EXPR_LIDENT@479..488
+                                Lident@479..488 "to_string"
+                              ARG_LIST@488..491
+                                LParen@488..489 "("
+                                ARG@489..490
+                                  EXPR_LIDENT@489..490
+                                    Lident@489..490 "x"
+                                RParen@490..491 ")"
+                          RParen@491..492 ")"
+                          Whitespace@492..493 " "
+                    InKeyword@493..495 "in"
+                    Whitespace@495..501 "\n\n    "
+                    EXPR_LET_BODY@501..571
+                      EXPR_LET@501..571
+                        LetKeyword@501..504 "let"
+                        Whitespace@504..505 " "
+                        PATTERN_VARIABLE@505..507
+                          Lident@505..506 "x"
+                          Whitespace@506..507 " "
+                        Eq@507..508 "="
+                        Whitespace@508..509 " "
+                        EXPR_LET_VALUE@509..516
+                          EXPR_TUPLE@509..516
+                            LParen@509..510 "("
+                            EXPR_INT@510..511
+                              Int@510..511 "3"
+                            Comma@511..512 ","
+                            Whitespace@512..513 " "
+                            EXPR_INT@513..514
+                              Int@513..514 "4"
+                            RParen@514..515 ")"
+                            Whitespace@515..516 " "
+                        InKeyword@516..518 "in"
+                        Whitespace@518..523 "\n    "
+                        EXPR_LET_BODY@523..571
+                          EXPR_LET@523..571
+                            LetKeyword@523..526 "let"
+                            Whitespace@526..527 " "
+                            PATTERN_WILDCARD@527..529
+                              WildcardKeyword@527..528 "_"
+                              Whitespace@528..529 " "
+                            Eq@529..530 "="
+                            Whitespace@530..531 " "
+                            EXPR_LET_VALUE@531..560
+                              EXPR_CALL@531..560
+                                EXPR_LIDENT@531..545
+                                  Lident@531..545 "string_println"
+                                ARG_LIST@545..560
+                                  LParen@545..546 "("
+                                  ARG@546..558
+                                    EXPR_CALL@546..558
+                                      EXPR_LIDENT@546..555
+                                        Lident@546..555 "to_string"
+                                      ARG_LIST@555..558
+                                        LParen@555..556 "("
+                                        ARG@556..557
+                                          EXPR_LIDENT@556..557
+                                            Lident@556..557 "x"
+                                        RParen@557..558 ")"
+                                  RParen@558..559 ")"
+                                  Whitespace@559..560 " "
+                            InKeyword@560..562 "in"
+                            Whitespace@562..568 "\n\n    "
+                            EXPR_LET_BODY@568..571
+                              EXPR_UNIT@568..571
+                                LParen@568..569 "("
+                                RParen@569..570 ")"
+                                Whitespace@570..571 "\n"
+      RBrace@571..572 "}"
+      Whitespace@572..573 "\n"

--- a/crates/compiler/src/tests/mod.rs
+++ b/crates/compiler/src/tests/mod.rs
@@ -88,12 +88,18 @@ fn run_test_cases(dir: &Path) -> anyhow::Result<()> {
 
             let input = std::fs::read_to_string(entry.path())?;
 
-            {
-                let result = parser::parse(&p, &input);
-                expect_test::expect_file![cst_filename].assert_eq(&debug_tree(&result.green_node));
+            let result = parser::parse(&p, &input);
+            if result.has_errors() {
+                panic!(
+                    "Parse errors in {}:\n{}",
+                    p.display(),
+                    result.format_errors(&input).join("\n")
+                );
             }
 
-            let result = parser::parse(&p, &input);
+            let cst_debug = debug_tree(&result.green_node);
+            expect_test::expect_file![cst_filename].assert_eq(&cst_debug);
+
             let root = MySyntaxNode::new_root(result.green_node);
             let cst = cst::cst::File::cast(root).unwrap();
             let ast = ast::lower::lower(cst).unwrap();

--- a/crates/compiler/src/tests/struct_type_test.rs
+++ b/crates/compiler/src/tests/struct_type_test.rs
@@ -9,6 +9,9 @@ use crate::{env::Env, tast};
 fn typecheck(src: &str) -> (tast::File, Env) {
     let path = PathBuf::from("test_structs.gom");
     let parsed = parser::parse(&path, src);
+    if parsed.has_errors() {
+        panic!("Parse errors:\n{}", parsed.format_errors(src).join("\n"));
+    }
     let root = MySyntaxNode::new_root(parsed.green_node);
     let cst = cst::cst::File::cast(root).expect("failed to cast syntax tree");
     let ast = ast::lower::lower(cst).expect("failed to lower to AST");

--- a/crates/compiler/src/tests/trait_impl_test.rs
+++ b/crates/compiler/src/tests/trait_impl_test.rs
@@ -8,6 +8,9 @@ use crate::{env::Env, tast};
 fn typecheck(src: &str) -> (tast::File, Env) {
     let path = PathBuf::from("dummy.src");
     let parsed = parser::parse(&path, src);
+    if parsed.has_errors() {
+        panic!("Parse errors:\n{}", parsed.format_errors(src).join("\n"));
+    }
     let root = MySyntaxNode::new_root(parsed.green_node);
     let cst = cst::cst::File::cast(root).expect("failed to cast syntax tree");
     let ast = ast::lower::lower(cst).expect("failed to lower to AST");

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -10,6 +10,6 @@ pub struct ParseError {
 impl ParseError {
     pub fn format_with_line_index(&self, index: &line_index::LineIndex) -> String {
         let line_col = index.line_col(self.range.start());
-        format!("{}:{}: {}", line_col.line, line_col.col, self.msg)
+        format!("{}:{}: {}", line_col.line + 1, line_col.col + 1, self.msg)
     }
 }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -21,6 +21,20 @@ pub struct ParseResult {
     pub errors: Vec<ParseError>,
 }
 
+impl ParseResult {
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    pub fn format_errors(&self, src: &str) -> Vec<String> {
+        let index = line_index::LineIndex::new(src);
+        self.errors
+            .iter()
+            .map(|error| error.format_with_line_index(&index))
+            .collect()
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct MarkerOpened {
     index: usize,

--- a/crates/parser/tests/structs.rs
+++ b/crates/parser/tests/structs.rs
@@ -5,6 +5,12 @@ use std::path::Path;
 fn check(input: &str, expect: Expect) {
     let path = Path::new("test.goml");
     let result = parse(path, input);
+    if result.has_errors() {
+        panic!(
+            "unexpected parse errors:\n{}",
+            result.format_errors(input).join("\n")
+        );
+    }
     expect.assert_eq(&debug_tree(&result.green_node));
 }
 

--- a/crates/wasm-app/src/lib.rs
+++ b/crates/wasm-app/src/lib.rs
@@ -1,10 +1,13 @@
 use cst::cst::CstNode;
-use parser::syntax::MySyntaxNode;
+use parser::{parser::ParseResult, syntax::MySyntaxNode};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn execute(src: &str) -> String {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return format_parse_errors(&result, src);
+    }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
     let ast = ast::lower::lower(cst).unwrap();
@@ -18,6 +21,9 @@ pub fn execute(src: &str) -> String {
 #[wasm_bindgen]
 pub fn compile_to_core(src: &str) -> String {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return format_parse_errors(&result, src);
+    }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
     let ast = ast::lower::lower(cst).unwrap();
@@ -31,6 +37,9 @@ pub fn compile_to_core(src: &str) -> String {
 #[wasm_bindgen]
 pub fn compile_to_mono(src: &str) -> String {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return format_parse_errors(&result, src);
+    }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
     let ast = ast::lower::lower(cst).unwrap();
@@ -45,6 +54,9 @@ pub fn compile_to_mono(src: &str) -> String {
 #[wasm_bindgen]
 pub fn compile_to_anf(src: &str) -> String {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return format_parse_errors(&result, src);
+    }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
     let ast = ast::lower::lower(cst).unwrap();
@@ -61,6 +73,9 @@ pub fn compile_to_anf(src: &str) -> String {
 #[wasm_bindgen]
 pub fn compile_to_go(src: &str) -> String {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return format_parse_errors(&result, src);
+    }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
     let ast = ast::lower::lower(cst).unwrap();
@@ -79,12 +94,18 @@ pub fn compile_to_go(src: &str) -> String {
 #[wasm_bindgen]
 pub fn get_cst(src: &str) -> String {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return format_parse_errors(&result, src);
+    }
     parser::debug_tree(&result.green_node)
 }
 
 #[wasm_bindgen]
 pub fn get_ast(src: &str) -> String {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return format_parse_errors(&result, src);
+    }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
     let ast = ast::lower::lower(cst).unwrap();
@@ -94,6 +115,9 @@ pub fn get_ast(src: &str) -> String {
 #[wasm_bindgen]
 pub fn get_tast(src: &str) -> String {
     let result = parser::parse(&std::path::PathBuf::from("dummy"), src);
+    if result.has_errors() {
+        return format_parse_errors(&result, src);
+    }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
     let ast = ast::lower::lower(cst).unwrap();
@@ -105,4 +129,13 @@ pub fn get_tast(src: &str) -> String {
 #[wasm_bindgen]
 pub fn hover(src: &str, line: u32, col: u32) -> Option<String> {
     compiler::query::hover_type(src, line, col)
+}
+
+fn format_parse_errors(result: &ParseResult, src: &str) -> String {
+    result
+        .format_errors(src)
+        .into_iter()
+        .map(|err| format!("error: {}", err))
+        .collect::<Vec<_>>()
+        .join("\n")
 }


### PR DESCRIPTION
## Summary
- add helpers on the parser to detect and format parse errors with 1-based positions
- stop the CLI, wasm bindings, and compiler tests from ignoring parse failures and surface diagnostics instead
- repair the ToString demo case and refresh its expectations while keeping clippy green

## Testing
- cargo fmt
- cargo check
- cargo test
- env UPDATE_EXPECT=1 cargo test -p compiler --lib tests::test_cases
- cargo clippy --all-targets --all-features -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68cc2881e90c832bbf2f4c7628bd6e5e