### PR TITLE
feat: collect parser diagnostics without panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "diagnostics"
+version = "0.0.0"
+dependencies = [
+ "text-size",
+]
+
+[[package]]
 name = "dissimilar"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +289,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 name = "parser"
 version = "0.0.0"
 dependencies = [
+ "diagnostics",
  "expect-test",
  "lexer",
  "line-index",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 edition = "2024"
 
 [workspace.dependencies]
+diagnostics = { path = "./crates/diagnostics", version = "0.0.0" }
 lexer = { path = "./crates/lexer", version = "0.0.0" }
 parser = { path = "./crates/parser", version = "0.0.0" }
 cst = { path = "./crates/cst", version = "0.0.0" }

--- a/crates/compiler/src/main.rs
+++ b/crates/compiler/src/main.rs
@@ -12,14 +12,16 @@ fn main() {
         std::process::exit(1);
     });
     let src = content;
-    let result = parser::parse(&file_path, &src);
-    if result.has_errors() {
-        for error in result.format_errors(&src) {
+    let parse_result = parser::parse(&file_path, &src);
+    let (green_node, diagnostics) = parse_result.into_parts();
+    if diagnostics.has_errors() {
+        for error in parser::format_parser_diagnostics(&diagnostics, &src) {
             eprintln!("error: {}: {}", file_path.display(), error);
         }
         std::process::exit(1);
     }
-    let root = MySyntaxNode::new_root(result.green_node);
+    // Future compilation stages can extend `diagnostics` with their own errors.
+    let root = MySyntaxNode::new_root(green_node);
     let cst = cst::cst::File::cast(root).unwrap();
     let ast = ast::lower::lower(cst).unwrap();
 

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "diagnostics"
+version = "0.0.0"
+edition.workspace = true
+
+[dependencies]
+text-size.workspace = true

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -1,0 +1,142 @@
+use std::borrow::Cow;
+
+use text_size::TextRange;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Stage {
+    Parser,
+    Typer,
+    Other(Cow<'static, str>),
+}
+
+impl Stage {
+    pub fn other(name: impl Into<Cow<'static, str>>) -> Self {
+        Stage::Other(name.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Stage::Parser => "parser",
+            Stage::Typer => "typer",
+            Stage::Other(name) => name.as_ref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    stage: Stage,
+    severity: Severity,
+    message: String,
+    range: Option<TextRange>,
+}
+
+impl Diagnostic {
+    pub fn new(stage: Stage, severity: Severity, message: impl Into<String>) -> Self {
+        Self {
+            stage,
+            severity,
+            message: message.into(),
+            range: None,
+        }
+    }
+
+    pub fn with_range(mut self, range: impl Into<Option<TextRange>>) -> Self {
+        self.range = range.into();
+        self
+    }
+
+    pub fn stage(&self) -> &Stage {
+        &self.stage
+    }
+
+    pub fn severity(&self) -> Severity {
+        self.severity
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn range(&self) -> Option<TextRange> {
+        self.range
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Diagnostics {
+    items: Vec<Diagnostic>,
+}
+
+impl Diagnostics {
+    pub fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    pub fn push(&mut self, diagnostic: Diagnostic) {
+        self.items.push(diagnostic);
+    }
+
+    pub fn extend(&mut self, diagnostics: impl IntoIterator<Item = Diagnostic>) {
+        self.items.extend(diagnostics);
+    }
+
+    pub fn append(&mut self, other: &mut Diagnostics) {
+        self.items.append(&mut other.items);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Diagnostic> {
+        self.items.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Diagnostic> {
+        self.items.iter_mut()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn has_errors(&self) -> bool {
+        self.items
+            .iter()
+            .any(|diagnostic| diagnostic.severity == Severity::Error)
+    }
+}
+
+impl IntoIterator for Diagnostics {
+    type Item = Diagnostic;
+    type IntoIter = std::vec::IntoIter<Diagnostic>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Diagnostics {
+    type Item = &'a Diagnostic;
+    type IntoIter = std::slice::Iter<'a, Diagnostic>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Diagnostics {
+    type Item = &'a mut Diagnostic;
+    type IntoIter = std::slice::IterMut<'a, Diagnostic>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter_mut()
+    }
+}

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition.workspace = true
 
 [dependencies]
+diagnostics.workspace = true
 lexer.workspace = true
 rowan.workspace = true
 text-size.workspace = true

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -1,15 +1,32 @@
-use text_size::TextRange;
+use diagnostics::{Diagnostic, Diagnostics, Severity, Stage};
 
-#[allow(unused)]
-#[derive(Debug)]
-pub struct ParseError {
-    pub msg: String,
-    pub range: TextRange,
+pub trait DiagnosticFormatExt {
+    fn format_with_line_index(&self, index: &line_index::LineIndex) -> String;
 }
 
-impl ParseError {
-    pub fn format_with_line_index(&self, index: &line_index::LineIndex) -> String {
-        let line_col = index.line_col(self.range.start());
-        format!("{}:{}: {}", line_col.line + 1, line_col.col + 1, self.msg)
+impl DiagnosticFormatExt for Diagnostic {
+    fn format_with_line_index(&self, index: &line_index::LineIndex) -> String {
+        if let Some(range) = self.range() {
+            let line_col = index.line_col(range.start());
+            format!(
+                "{}:{}: {}",
+                line_col.line + 1,
+                line_col.col + 1,
+                self.message()
+            )
+        } else {
+            self.message().to_string()
+        }
     }
+}
+
+pub fn format_parser_diagnostics(diagnostics: &Diagnostics, src: &str) -> Vec<String> {
+    let index = line_index::LineIndex::new(src);
+    diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.severity() == Severity::Error && diagnostic.stage() == &Stage::Parser
+        })
+        .map(|diagnostic| diagnostic.format_with_line_index(&index))
+        .collect()
 }

--- a/crates/parser/src/input.rs
+++ b/crates/parser/src/input.rs
@@ -1,4 +1,5 @@
 use lexer::{T, Token, TokenKind};
+use text_size::TextRange;
 
 pub struct Input<'t> {
     pub tokens: Vec<Token<'t>>,
@@ -49,5 +50,9 @@ impl<'t> Input<'t> {
 
     fn peek_raw_kind(&self) -> TokenKind {
         self.tokens.get(self.cursor).map_or(T![eof], |it| it.kind)
+    }
+
+    pub fn current_range(&self) -> Option<TextRange> {
+        self.tokens.get(self.cursor).map(|token| token.range)
     }
 }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,5 +1,8 @@
 use std::path::Path;
 
+pub use diagnostics::{
+    Diagnostic, Diagnostics, Severity as DiagnosticSeverity, Stage as DiagnosticStage,
+};
 use parser::{ParseResult, Parser};
 use syntax::MySyntaxNode;
 
@@ -11,6 +14,8 @@ pub mod input;
 pub mod parser;
 pub mod pattern;
 pub mod syntax;
+
+pub use error::{DiagnosticFormatExt, format_parser_diagnostics};
 
 pub fn parse(filename: &Path, input: &str) -> ParseResult {
     let toks = lexer::lex(input);

--- a/crates/parser/tests/structs.rs
+++ b/crates/parser/tests/structs.rs
@@ -118,3 +118,14 @@ fn struct_literal_expr() {
                   RBrace@19..20 "}""#]],
     );
 }
+
+#[test]
+fn reports_parse_errors_without_panicking() {
+    let path = Path::new("test.goml");
+    let src = "fn foo(";
+    let result = parse(path, src);
+    assert!(result.has_errors());
+    let errors = result.format_errors(src);
+    assert!(!errors.is_empty());
+    assert!(errors[0].contains("expect"));
+}


### PR DESCRIPTION
## Summary
- add a diagnostics crate that models severities and compiler stages so parsing errors can be accumulated
- switch the parser to emit Diagnostics instead of panicking, including a guard when the parser stops consuming tokens
- expose formatting helpers, update the CLI to consume the new diagnostics, and add a regression test for parse errors

## Testing
- cargo fmt
- cargo check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68ccb3105588832b8cd972974f2ecd17