### PR TITLE
perf: cache compiled go snippets during tests

### DIFF
--- a/crates/compiler/src/tests/mod.rs
+++ b/crates/compiler/src/tests/mod.rs
@@ -1,5 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::Context;
 use anyhow::bail;
@@ -41,39 +41,126 @@ fn go_bin() -> PathBuf {
 }
 
 fn execute_single_go_file(input: &Path) -> anyhow::Result<String> {
-    use std::io::Write;
     use std::process::{Command, Stdio};
+
     dbg!(&input);
 
-    let dir = tempfile::tempdir().with_context(|| "Failed to create temporary directory")?;
-
-    // copy go_file into tempdir, and rename extension name to .go
-    let main_go_file = dir.path().join("main.go");
-    std::fs::copy(input, &main_go_file).with_context(|| {
-        format!(
-            "Failed to copy go file from {} to {}",
-            input.display(),
-            main_go_file.display()
-        )
-    })?;
-
     let go = go_bin();
-    let mut child = Command::new(&go)
-        .arg("run")
-        .arg("main.go")
-        .current_dir(dir.path())
-        .stdin(Stdio::piped())
+    let go_version = go_version(&go)?;
+    let go_source = std::fs::read(input)
+        .with_context(|| format!("Failed to read go source from {}", input.display()))?;
+
+    let cache_dir = go_cache_dir(&go_version, &go_source, input)?;
+    let main_go_file = cache_dir.join("main.go");
+    let binary_path = cache_dir.join(if cfg!(windows) { "main.exe" } else { "main" });
+
+    if !binary_path.exists() {
+        std::fs::create_dir_all(&cache_dir)
+            .with_context(|| format!("Failed to create {}", cache_dir.display()))?;
+        std::fs::write(&main_go_file, &go_source)
+            .with_context(|| format!("Failed to write go source to {}", main_go_file.display()))?;
+
+        let output = Command::new(&go)
+            .arg("build")
+            .arg("-o")
+            .arg(&binary_path)
+            .arg("main.go")
+            .current_dir(&cache_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| format!("Failed to build go binary at {}", cache_dir.display()))?;
+
+        if !output.status.success() {
+            let _ = std::fs::remove_file(&binary_path);
+            let stderr = if output.stderr.is_empty() {
+                &output.stdout
+            } else {
+                &output.stderr
+            };
+            return Ok(String::from_utf8_lossy(stderr).to_string());
+        }
+    }
+
+    let output = Command::new(&binary_path)
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-    let stdin = child.stdin.as_mut().unwrap();
-    stdin.write_all(b"").unwrap();
-    let output = child.wait_with_output()?;
+        .output()
+        .with_context(|| format!("Failed to run go binary at {}", binary_path.display()))?;
+
     if !output.status.success() {
         Ok(String::from_utf8_lossy(&output.stderr).to_string())
     } else {
         Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+}
+
+fn go_version(go: &Path) -> anyhow::Result<String> {
+    static VERSION: OnceLock<String> = OnceLock::new();
+    if let Some(version) = VERSION.get() {
+        return Ok(version.clone());
+    }
+
+    let output = std::process::Command::new(go)
+        .arg("version")
+        .output()
+        .with_context(|| format!("Failed to query Go toolchain at {}", go.display()))?;
+    if !output.status.success() {
+        bail!("`go version` exited with status {}", output.status);
+    }
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let _ = VERSION.set(version.clone());
+    Ok(version)
+}
+
+fn go_cache_dir(go_version: &str, source: &[u8], input: &Path) -> anyhow::Result<PathBuf> {
+    let base = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"));
+    let root = base.join("go-run-cache");
+    std::fs::create_dir_all(&root)?;
+
+    let mut hasher = Fnv1aHasher::new();
+    hasher.update(go_version.as_bytes());
+    hasher.update(source);
+    let path_string = input.to_string_lossy();
+    hasher.update(path_string.as_bytes());
+    let key = hasher.finish_hex();
+
+    Ok(root.join(key))
+}
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest_dir.ancestors() {
+        if ancestor.join("Cargo.lock").exists() {
+            return ancestor.to_path_buf();
+        }
+    }
+    manifest_dir
+}
+
+struct Fnv1aHasher {
+    hash: u64,
+}
+
+impl Fnv1aHasher {
+    fn new() -> Self {
+        Self {
+            hash: 0xcbf29ce484222325,
+        }
+    }
+
+    fn update(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.hash ^= u64::from(byte);
+            self.hash = self.hash.wrapping_mul(0x100000001b3);
+        }
+    }
+
+    fn finish_hex(&self) -> String {
+        format!("{:016x}", self.hash)
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the per-test `go run` invocation with a cached `go build` + binary execution so repeated runs stop recompiling every Go snippet
- key the cache by Go toolchain version, generated source, and case path, and store the binaries under `target/go-run-cache`
- add helpers for querying the Go version, resolving the workspace target dir, and hashing cache keys

## Testing
- cargo test -p compiler test_cases -- --nocapture
- cargo test -p compiler

------
https://chatgpt.com/codex/tasks/task_e_68cd4675f9c4832b93e33ea344a28d36