### PR TITLE
fix: recover missing patterns in let expressions

### DIFF
--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -111,7 +111,7 @@ pub fn match_arm_list(p: &mut Parser) {
 
 fn match_arm(p: &mut Parser) {
     let m = p.open();
-    super::pattern::pattern(p);
+    let _ = super::pattern::pattern(p);
     p.expect(T![=>]);
     if p.at(T!['{']) {
         block(p);
@@ -186,7 +186,7 @@ fn let_expr(p: &mut Parser) {
     assert!(p.at(T![let]));
     let m = p.open();
     p.expect(T![let]);
-    pattern::pattern(p);
+    let _ = pattern::pattern(p);
     p.expect(T![=]);
     if !p.at_any(EXPR_FIRST) {
         p.advance_with_error("let [_] expected an expression");

--- a/crates/parser/tests/structs.rs
+++ b/crates/parser/tests/structs.rs
@@ -129,3 +129,13 @@ fn reports_parse_errors_without_panicking() {
     assert!(!errors.is_empty());
     assert!(errors[0].contains("expect"));
 }
+
+#[test]
+fn let_expression_without_pattern_reports_error() {
+    let path = Path::new("test.goml");
+    let src = "let = 42 in foo";
+    let result = parse(path, src);
+    assert!(result.has_errors());
+    let errors = result.format_errors(src);
+    assert!(errors.iter().any(|msg| msg.contains("expected a pattern")));
+}


### PR DESCRIPTION
## Summary
- make pattern parsing resilient by returning `ErrorTree` nodes when no pattern token is present
- adjust let-expression parsing to consume the new pattern result and keep parsing
- add a regression test ensuring incomplete let bindings report diagnostics instead of panicking

## Testing
- cargo fmt
- cargo check -p parser
- cargo test -p parser
- cargo clippy -p parser --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68cd791b81bc832bb54db42300c440d2