### PR TITLE
feat: surface typer diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "anyhow",
  "ast",
  "cst",
+ "diagnostics",
  "ena",
  "expect-test",
  "im",

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -15,6 +15,7 @@ anyhow.workspace = true
 line-index.workspace = true
 rowan.workspace = true
 indexmap.workspace = true
+diagnostics.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/compiler/src/tests/trait_impl_test.rs
+++ b/crates/compiler/src/tests/trait_impl_test.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use cst::cst::CstNode;
 use parser::syntax::MySyntaxNode;
 
-use crate::{env::Env, tast};
+use crate::{
+    env::{Env, format_typer_diagnostics},
+    tast,
+};
 
 fn typecheck(src: &str) -> (tast::File, Env) {
     let path = PathBuf::from("dummy.src");
@@ -17,9 +20,25 @@ fn typecheck(src: &str) -> (tast::File, Env) {
     crate::typer::check_file(ast)
 }
 
+fn expect_single_error(src: &str, expected: &str) {
+    let (_, env) = typecheck(src);
+    let diagnostics = format_typer_diagnostics(&env.diagnostics);
+    assert_eq!(
+        diagnostics.len(),
+        1,
+        "expected exactly one diagnostic, got {:?}",
+        diagnostics
+    );
+    assert!(
+        diagnostics[0].contains(expected),
+        "expected diagnostic to contain `{}`, got `{}`",
+        expected,
+        diagnostics[0]
+    );
+}
+
 #[test]
-#[should_panic(expected = "Trait Display::show expected return type")]
-fn impl_with_mismatched_return_type_panics() {
+fn impl_with_mismatched_return_type_reports_diagnostic() {
     let src = r#"
 trait Display {
     fn show(Self) -> string;
@@ -30,12 +49,11 @@ impl Display for int {
 }
 "#;
 
-    let _ = typecheck(src);
+    expect_single_error(src, "Trait Display::show expected return type");
 }
 
 #[test]
-#[should_panic(expected = "Trait Display::show parameter 0 expected type")]
-fn impl_with_mismatched_param_type_panics() {
+fn impl_with_mismatched_param_type_reports_diagnostic() {
     let src = r#"
 trait Display {
     fn show(Self) -> string;
@@ -46,12 +64,11 @@ impl Display for int {
 }
 "#;
 
-    let _ = typecheck(src);
+    expect_single_error(src, "Trait Display::show parameter 0 expected type");
 }
 
 #[test]
-#[should_panic(expected = "Trait Add::add expects 2 parameters but impl has 1")]
-fn impl_with_parameter_arity_mismatch_panics() {
+fn impl_with_parameter_arity_mismatch_reports_diagnostic() {
     let src = r#"
 trait Add {
     fn add(Self, Self) -> Self;
@@ -62,12 +79,11 @@ impl Add for int {
 }
 "#;
 
-    let _ = typecheck(src);
+    expect_single_error(src, "Trait Add::add expects 2 parameters but impl has 1");
 }
 
 #[test]
-#[should_panic(expected = "Trait Display implementation for TInt is missing method debug")]
-fn impl_missing_trait_method_panics() {
+fn impl_missing_trait_method_reports_diagnostic() {
     let src = r#"
 trait Display {
     fn show(Self) -> string;
@@ -79,12 +95,14 @@ impl Display for int {
 }
 "#;
 
-    let _ = typecheck(src);
+    expect_single_error(
+        src,
+        "Trait Display implementation for TInt is missing method debug",
+    );
 }
 
 #[test]
-#[should_panic(expected = "Method extra is not declared in trait Display")]
-fn impl_with_extra_method_panics() {
+fn impl_with_extra_method_reports_diagnostic() {
     let src = r#"
 trait Display {
     fn show(Self) -> string;
@@ -96,17 +114,16 @@ impl Display for int {
 }
 "#;
 
-    let _ = typecheck(src);
+    expect_single_error(src, "Method extra is not declared in trait Display");
 }
 
 #[test]
-#[should_panic(expected = "Trait Unknown is not defined")]
-fn impl_for_unknown_trait_panics() {
+fn impl_for_unknown_trait_reports_diagnostic() {
     let src = r#"
 impl Unknown for int {
     fn mystery(self: int) -> int { self }
 }
 "#;
 
-    let _ = typecheck(src);
+    expect_single_error(src, "Trait Unknown is not defined");
 }

--- a/crates/wasm-app/src/lib.rs
+++ b/crates/wasm-app/src/lib.rs
@@ -1,5 +1,7 @@
 use cst::cst::CstNode;
 use parser::{parser::ParseResult, syntax::MySyntaxNode};
+
+use compiler::env::format_typer_diagnostics;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -13,6 +15,14 @@ pub fn execute(src: &str) -> String {
     let ast = ast::lower::lower(cst).unwrap();
 
     let (tast, env) = compiler::typer::check_file(ast);
+    let typer_errors = format_typer_diagnostics(&env.diagnostics);
+    if !typer_errors.is_empty() {
+        return typer_errors
+            .into_iter()
+            .map(|err| format!("error: {}", err))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
     let core = compiler::compile_match::compile_file(&env, &tast);
     let _ = core;
     "not support for now".into()
@@ -29,6 +39,14 @@ pub fn compile_to_core(src: &str) -> String {
     let ast = ast::lower::lower(cst).unwrap();
 
     let (tast, env) = compiler::typer::check_file(ast);
+    let typer_errors = format_typer_diagnostics(&env.diagnostics);
+    if !typer_errors.is_empty() {
+        return typer_errors
+            .into_iter()
+            .map(|err| format!("error: {}", err))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
     let core = compiler::compile_match::compile_file(&env, &tast);
 
     core.to_pretty(&env, 120)
@@ -45,6 +63,14 @@ pub fn compile_to_mono(src: &str) -> String {
     let ast = ast::lower::lower(cst).unwrap();
 
     let (tast, mut env) = compiler::typer::check_file(ast);
+    let typer_errors = format_typer_diagnostics(&env.diagnostics);
+    if !typer_errors.is_empty() {
+        return typer_errors
+            .into_iter()
+            .map(|err| format!("error: {}", err))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
     let core = compiler::compile_match::compile_file(&env, &tast);
 
     let mono = compiler::mono::mono(&mut env, core);
@@ -62,6 +88,14 @@ pub fn compile_to_anf(src: &str) -> String {
     let ast = ast::lower::lower(cst).unwrap();
 
     let (tast, mut env) = compiler::typer::check_file(ast);
+    let typer_errors = format_typer_diagnostics(&env.diagnostics);
+    if !typer_errors.is_empty() {
+        return typer_errors
+            .into_iter()
+            .map(|err| format!("error: {}", err))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
     let core = compiler::compile_match::compile_file(&env, &tast);
 
     let mono = compiler::mono::mono(&mut env, core);
@@ -81,6 +115,14 @@ pub fn compile_to_go(src: &str) -> String {
     let ast = ast::lower::lower(cst).unwrap();
 
     let (tast, mut env) = compiler::typer::check_file(ast);
+    let typer_errors = format_typer_diagnostics(&env.diagnostics);
+    if !typer_errors.is_empty() {
+        return typer_errors
+            .into_iter()
+            .map(|err| format!("error: {}", err))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
     let core = compiler::compile_match::compile_file(&env, &tast);
 
     let mono = compiler::mono::mono(&mut env, core);
@@ -123,6 +165,14 @@ pub fn get_tast(src: &str) -> String {
     let ast = ast::lower::lower(cst).unwrap();
 
     let (tast, env) = compiler::typer::check_file(ast);
+    let typer_errors = format_typer_diagnostics(&env.diagnostics);
+    if !typer_errors.is_empty() {
+        return typer_errors
+            .into_iter()
+            .map(|err| format!("error: {}", err))
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
     tast.to_pretty(&env, 120)
 }
 


### PR DESCRIPTION
## Summary
- capture typer errors in the environment instead of panicking and surface them through `TypeInference` and trait-impl validation
- expose recorded type errors through the CLI and Wasm bindings using a shared formatter
- update trait implementation regression tests to assert on reported diagnostics

## Testing
- cargo test -p compiler

------
https://chatgpt.com/codex/tasks/task_e_68dbdc17797c832ba23d6a1795fcae6f