### PR TITLE
refactor: centralize compiler pipeline

### DIFF
--- a/crates/compiler/src/anf.rs
+++ b/crates/compiler/src/anf.rs
@@ -2,12 +2,12 @@ pub type Ty = crate::tast::Ty;
 use crate::tast::Constructor;
 use crate::{core, env::Env};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct File {
     pub toplevels: Vec<Fn>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Fn {
     pub name: String,
     pub params: Vec<(String, Ty)>,

--- a/crates/compiler/src/core.rs
+++ b/crates/compiler/src/core.rs
@@ -1,12 +1,12 @@
 pub type Ty = crate::tast::Ty;
 use crate::tast::Constructor;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct File {
     pub toplevels: Vec<Fn>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Fn {
     pub name: String,
     pub params: Vec<(String, Ty)>,

--- a/crates/compiler/src/env.rs
+++ b/crates/compiler/src/env.rs
@@ -70,7 +70,7 @@ pub enum Constraint {
     },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(unused)]
 pub struct Env {
     counter: Cell<i32>,

--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -5,6 +5,7 @@ pub mod env;
 pub mod go;
 pub mod mangle;
 pub mod mono;
+pub mod pipeline;
 pub mod pprint;
 pub mod query;
 pub mod rename;

--- a/crates/compiler/src/pipeline.rs
+++ b/crates/compiler/src/pipeline.rs
@@ -1,0 +1,93 @@
+use std::path::Path;
+
+use ast::ast;
+use cst::cst::{CstNode, File as CstFile};
+use diagnostics::Diagnostics;
+use parser::{self, syntax::MySyntaxNode};
+use rowan::GreenNode;
+
+use crate::{
+    anf, compile_match,
+    env::Env,
+    go::{self, goast},
+    mono, tast, typer,
+};
+
+#[derive(Debug)]
+pub struct Compilation {
+    pub green_node: GreenNode,
+    pub cst: CstFile,
+    pub ast: ast::File,
+    pub tast: tast::File,
+    pub typer_env: Env,
+    pub env: Env,
+    pub core: crate::core::File,
+    pub mono: crate::core::File,
+    pub anf: anf::File,
+    pub go: goast::File,
+}
+
+#[derive(Debug, Clone)]
+pub enum CompilationError {
+    Parser { diagnostics: Diagnostics },
+    Typer { diagnostics: Diagnostics },
+}
+
+impl CompilationError {
+    pub fn diagnostics(&self) -> &Diagnostics {
+        match self {
+            CompilationError::Parser { diagnostics } | CompilationError::Typer { diagnostics } => {
+                diagnostics
+            }
+        }
+    }
+
+    pub fn into_diagnostics(self) -> Diagnostics {
+        match self {
+            CompilationError::Parser { diagnostics } | CompilationError::Typer { diagnostics } => {
+                diagnostics
+            }
+        }
+    }
+}
+
+pub fn compile(path: &Path, src: &str) -> Result<Compilation, CompilationError> {
+    let parse_result = parser::parse(path, src);
+    if parse_result.has_errors() {
+        return Err(CompilationError::Parser {
+            diagnostics: parse_result.into_diagnostics(),
+        });
+    }
+
+    let green_node = parse_result.green_node.clone();
+    let root = MySyntaxNode::new_root(parse_result.green_node);
+    let cst = CstFile::cast(root).expect("failed to cast CST file");
+    let ast = ::ast::lower::lower(cst.clone()).expect("lowering produced no AST");
+
+    let (tast, mut env) = typer::check_file(ast.clone());
+    if env.diagnostics.has_errors() {
+        return Err(CompilationError::Typer {
+            diagnostics: env.diagnostics.clone(),
+        });
+    }
+
+    let typer_env = env.clone();
+
+    let core = compile_match::compile_file(&env, &tast);
+    let mono = mono::mono(&mut env, core.clone());
+    let anf = anf::anf_file(&env, mono.clone());
+    let go = go::compile::go_file(&env, anf.clone());
+
+    Ok(Compilation {
+        green_node,
+        cst,
+        ast,
+        tast,
+        typer_env,
+        env,
+        core,
+        mono,
+        anf,
+        go,
+    })
+}


### PR DESCRIPTION
## Summary
- introduce a shared `pipeline` module that produces all compiler stages and errors in one place
- update the CLI and regression tests to drive compilation through the shared pipeline
- derive `Clone` for IR structs and `Env`, and run Go snapshot executions from generated source

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dbfa96ce4c832b96726f147ca1d61a