### PR TITLE
feat: centralize builtin function signatures in env

### DIFF
--- a/crates/compiler/src/env.rs
+++ b/crates/compiler/src/env.rs
@@ -22,6 +22,57 @@ pub struct StructDef {
     pub fields: Vec<(Lident, tast::Ty)>,
 }
 
+fn builtin_functions() -> IndexMap<String, tast::Ty> {
+    let mut funcs = IndexMap::new();
+
+    let make_fn_ty = |params: Vec<tast::Ty>, ret: tast::Ty| tast::Ty::TFunc {
+        params,
+        ret_ty: Box::new(ret),
+    };
+
+    funcs.insert(
+        "unit_to_string".to_string(),
+        make_fn_ty(vec![tast::Ty::TUnit], tast::Ty::TString),
+    );
+    funcs.insert(
+        "bool_to_string".to_string(),
+        make_fn_ty(vec![tast::Ty::TBool], tast::Ty::TString),
+    );
+    funcs.insert(
+        "int_to_string".to_string(),
+        make_fn_ty(vec![tast::Ty::TInt], tast::Ty::TString),
+    );
+    funcs.insert(
+        "int_add".to_string(),
+        make_fn_ty(vec![tast::Ty::TInt, tast::Ty::TInt], tast::Ty::TInt),
+    );
+    funcs.insert(
+        "int_sub".to_string(),
+        make_fn_ty(vec![tast::Ty::TInt, tast::Ty::TInt], tast::Ty::TInt),
+    );
+    funcs.insert(
+        "int_less".to_string(),
+        make_fn_ty(vec![tast::Ty::TInt, tast::Ty::TInt], tast::Ty::TBool),
+    );
+    funcs.insert(
+        "string_add".to_string(),
+        make_fn_ty(
+            vec![tast::Ty::TString, tast::Ty::TString],
+            tast::Ty::TString,
+        ),
+    );
+    funcs.insert(
+        "string_print".to_string(),
+        make_fn_ty(vec![tast::Ty::TString], tast::Ty::TUnit),
+    );
+    funcs.insert(
+        "string_println".to_string(),
+        make_fn_ty(vec![tast::Ty::TString], tast::Ty::TUnit),
+    );
+
+    funcs
+}
+
 pub fn encode_trait_impl(trait_name: &Uident, type_name: &tast::Ty) -> String {
     let trait_name = trait_name.0.clone();
     let type_name = type_name.clone();
@@ -97,7 +148,7 @@ impl Env {
             counter: Cell::new(0),
             enums: IndexMap::new(),
             structs: IndexMap::new(),
-            funcs: IndexMap::new(),
+            funcs: builtin_functions(),
             trait_defs: IndexMap::new(),
             overloaded_funcs_to_trait_name: IndexMap::new(),
             trait_impls: IndexMap::new(),

--- a/crates/compiler/src/tests/builtin_functions_test.rs
+++ b/crates/compiler/src/tests/builtin_functions_test.rs
@@ -1,0 +1,31 @@
+use crate::{env::Env, tast};
+
+#[test]
+fn env_registers_builtin_function_signatures() {
+    let env = Env::new();
+
+    match env.get_type_of_function("string_print") {
+        Some(tast::Ty::TFunc { params, ret_ty }) => {
+            assert_eq!(params.len(), 1);
+            assert!(matches!(params[0], tast::Ty::TString));
+            assert!(matches!(ret_ty.as_ref(), tast::Ty::TUnit));
+        }
+        other => panic!(
+            "expected string_print to have a function type signature, got {:?}",
+            other
+        ),
+    }
+
+    match env.get_type_of_function("int_add") {
+        Some(tast::Ty::TFunc { params, ret_ty }) => {
+            assert_eq!(params.len(), 2);
+            assert!(matches!(params[0], tast::Ty::TInt));
+            assert!(matches!(params[1], tast::Ty::TInt));
+            assert!(matches!(ret_ty.as_ref(), tast::Ty::TInt));
+        }
+        other => panic!(
+            "expected int_add to have a function type signature, got {:?}",
+            other
+        ),
+    }
+}

--- a/crates/compiler/src/tests/mod.rs
+++ b/crates/compiler/src/tests/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     pipeline::{self, CompilationError},
 };
 
+mod builtin_functions_test;
 mod query_test;
 mod struct_type_test;
 mod trait_impl_test;

--- a/crates/compiler/src/tests/typer/builtin_function_type_mismatch.src
+++ b/crates/compiler/src/tests/typer/builtin_function_type_mismatch.src
@@ -1,0 +1,4 @@
+fn main() {
+    let _ = string_print(123) in
+    ()
+}

--- a/crates/compiler/src/tests/typer/builtin_function_type_mismatch.src.diag
+++ b/crates/compiler/src/tests/typer/builtin_function_type_mismatch.src.diag
@@ -1,0 +1,3 @@
+type not equal TString and TInt
+Type variable TypeVar(1) not resolved
+Type variable TypeVar(0) not resolved


### PR DESCRIPTION
## Summary
- register builtin/runtime function type signatures in the compiler environment on creation
- resolve call expressions using environment-registered signatures before falling back to overload resolution
- add regression tests covering builtin signature availability and type errors

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dd1936d4a8832bb0da1ddb27ed6f37