### PR TITLE
feat: support binary operators through the pipeline

### DIFF
--- a/crates/ast/src/ast.rs
+++ b/crates/ast/src/ast.rs
@@ -40,6 +40,25 @@ impl BinaryOp {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum UnaryOp {
+    Neg,
+}
+
+impl UnaryOp {
+    pub fn symbol(self) -> &'static str {
+        match self {
+            Self::Neg => "-",
+        }
+    }
+
+    pub fn method_name(self) -> &'static str {
+        match self {
+            Self::Neg => "neg",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Ty {
     TUnit,
@@ -148,6 +167,10 @@ pub enum Expr {
     ECall {
         func: Lident,
         args: Vec<Expr>,
+    },
+    EUnary {
+        op: UnaryOp,
+        expr: Box<Expr>,
     },
     EBinary {
         op: BinaryOp,

--- a/crates/ast/src/ast.rs
+++ b/crates/ast/src/ast.rs
@@ -12,6 +12,34 @@ impl Uident {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BinaryOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+}
+
+impl BinaryOp {
+    pub fn symbol(self) -> &'static str {
+        match self {
+            Self::Add => "+",
+            Self::Sub => "-",
+            Self::Mul => "*",
+            Self::Div => "/",
+        }
+    }
+
+    pub fn method_name(self) -> &'static str {
+        match self {
+            Self::Add => "add",
+            Self::Sub => "sub",
+            Self::Mul => "mul",
+            Self::Div => "div",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Ty {
     TUnit,
@@ -120,6 +148,15 @@ pub enum Expr {
     ECall {
         func: Lident,
         args: Vec<Expr>,
+    },
+    EBinary {
+        op: BinaryOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
+    EProj {
+        tuple: Box<Expr>,
+        index: usize,
     },
 }
 

--- a/crates/ast/src/ast_pprint.rs
+++ b/crates/ast/src/ast_pprint.rs
@@ -191,6 +191,16 @@ impl Expr {
                         .group()
                 }
             }
+            Self::EBinary { op, lhs, rhs } => lhs
+                .to_doc()
+                .append(RcDoc::space())
+                .append(RcDoc::text(op.symbol()))
+                .append(RcDoc::space())
+                .append(rhs.to_doc()),
+            Self::EProj { tuple, index } => tuple
+                .to_doc()
+                .append(RcDoc::text("."))
+                .append(RcDoc::text(index.to_string())),
         }
     }
 

--- a/crates/ast/src/ast_pprint.rs
+++ b/crates/ast/src/ast_pprint.rs
@@ -191,6 +191,7 @@ impl Expr {
                         .group()
                 }
             }
+            Self::EUnary { op, expr } => RcDoc::text(op.symbol()).append(expr.to_doc()).group(),
             Self::EBinary { op, lhs, rhs } => lhs
                 .to_doc()
                 .append(RcDoc::space())

--- a/crates/ast/src/lower.rs
+++ b/crates/ast/src/lower.rs
@@ -370,6 +370,23 @@ fn lower_expr(node: cst::Expr) -> Option<ast::Expr> {
                 body: Box::new(body),
             })
         }
+        cst::Expr::PrefixExpr(it) => {
+            let expr = it
+                .expr()
+                .and_then(lower_expr)
+                .unwrap_or_else(|| panic!("Prefix expression missing operand"));
+            let op_token = it
+                .op()
+                .unwrap_or_else(|| panic!("Prefix expression missing operator"));
+
+            match op_token.kind() {
+                MySyntaxKind::Minus => Some(ast::Expr::EUnary {
+                    op: ast::UnaryOp::Neg,
+                    expr: Box::new(expr),
+                }),
+                kind => panic!("Unsupported prefix operator: {:?}", kind),
+            }
+        }
         cst::Expr::BinaryExpr(it) => {
             let mut exprs = it.exprs();
             let lhs_cst = exprs

--- a/crates/ast/src/lower.rs
+++ b/crates/ast/src/lower.rs
@@ -2,7 +2,7 @@ use crate::ast;
 
 use ::cst::cst::CstNode;
 use ::cst::{cst, support};
-use parser::syntax::MySyntaxNodePtr;
+use parser::syntax::{MySyntaxKind, MySyntaxNodePtr};
 
 pub fn lower(node: cst::File) -> Option<ast::File> {
     let items = node.items().flat_map(lower_item).collect();
@@ -370,8 +370,75 @@ fn lower_expr(node: cst::Expr) -> Option<ast::Expr> {
                 body: Box::new(body),
             })
         }
-        cst::Expr::BinaryExpr(_it) => {
-            todo!()
+        cst::Expr::BinaryExpr(it) => {
+            let mut exprs = it.exprs();
+            let lhs_cst = exprs
+                .next()
+                .unwrap_or_else(|| panic!("Binary expression missing lhs"));
+            let rhs_cst = exprs
+                .next()
+                .unwrap_or_else(|| panic!("Binary expression missing rhs"));
+
+            let lhs = lower_expr(lhs_cst)?;
+            let op_token = it
+                .op()
+                .unwrap_or_else(|| panic!("Binary expression missing operator"));
+
+            match op_token.kind() {
+                MySyntaxKind::Plus => {
+                    let rhs = lower_expr(rhs_cst)?;
+                    Some(ast::Expr::EBinary {
+                        op: ast::BinaryOp::Add,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                    })
+                }
+                MySyntaxKind::Minus => {
+                    let rhs = lower_expr(rhs_cst)?;
+                    Some(ast::Expr::EBinary {
+                        op: ast::BinaryOp::Sub,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                    })
+                }
+                MySyntaxKind::Star => {
+                    let rhs = lower_expr(rhs_cst)?;
+                    Some(ast::Expr::EBinary {
+                        op: ast::BinaryOp::Mul,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                    })
+                }
+                MySyntaxKind::Slash => {
+                    let rhs = lower_expr(rhs_cst)?;
+                    Some(ast::Expr::EBinary {
+                        op: ast::BinaryOp::Div,
+                        lhs: Box::new(lhs),
+                        rhs: Box::new(rhs),
+                    })
+                }
+                MySyntaxKind::Dot => match rhs_cst {
+                    cst::Expr::IntExpr(int_expr) => {
+                        let value = int_expr
+                            .value()
+                            .unwrap_or_else(|| panic!("Tuple projection missing index"))
+                            .to_string();
+                        let index = value
+                            .parse::<usize>()
+                            .unwrap_or_else(|_| panic!("Invalid tuple index: {}", value));
+                        Some(ast::Expr::EProj {
+                            tuple: Box::new(lhs),
+                            index,
+                        })
+                    }
+                    _ => {
+                        panic!("Unsupported field access expression: {:?}", rhs_cst);
+                    }
+                },
+                kind => {
+                    panic!("Unsupported binary operator: {:?}", kind);
+                }
+            }
         }
     }
 }

--- a/crates/compiler/src/env.rs
+++ b/crates/compiler/src/env.rs
@@ -43,6 +43,10 @@ fn builtin_functions() -> IndexMap<String, tast::Ty> {
         make_fn_ty(vec![tast::Ty::TInt], tast::Ty::TString),
     );
     funcs.insert(
+        "int_neg".to_string(),
+        make_fn_ty(vec![tast::Ty::TInt], tast::Ty::TInt),
+    );
+    funcs.insert(
         "int_add".to_string(),
         make_fn_ty(vec![tast::Ty::TInt, tast::Ty::TInt], tast::Ty::TInt),
     );

--- a/crates/compiler/src/env.rs
+++ b/crates/compiler/src/env.rs
@@ -51,6 +51,14 @@ fn builtin_functions() -> IndexMap<String, tast::Ty> {
         make_fn_ty(vec![tast::Ty::TInt, tast::Ty::TInt], tast::Ty::TInt),
     );
     funcs.insert(
+        "int_mul".to_string(),
+        make_fn_ty(vec![tast::Ty::TInt, tast::Ty::TInt], tast::Ty::TInt),
+    );
+    funcs.insert(
+        "int_div".to_string(),
+        make_fn_ty(vec![tast::Ty::TInt, tast::Ty::TInt], tast::Ty::TInt),
+    );
+    funcs.insert(
         "int_less".to_string(),
         make_fn_ty(vec![tast::Ty::TInt, tast::Ty::TInt], tast::Ty::TBool),
     );

--- a/crates/compiler/src/go/runtime.rs
+++ b/crates/compiler/src/go/runtime.rs
@@ -3,6 +3,7 @@ use crate::go::goast::{self, EmbededRawString};
 // unit_to_string(x : struct{}) string
 // bool_to_string(x : bool) string
 // int_to_string(x : int) string
+// int_neg(x : int) int
 // int_add(x : int, y : int) int
 // int_sub(x : int, y : int) int
 // int_mul(x : int, y : int) int
@@ -33,6 +34,10 @@ func bool_to_string(x bool) string {
 
 func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
+}
+
+func int_neg(x int) int {
+    return -x
 }
 
 func int_add(x int, y int) int {

--- a/crates/compiler/src/go/runtime.rs
+++ b/crates/compiler/src/go/runtime.rs
@@ -5,6 +5,8 @@ use crate::go::goast::{self, EmbededRawString};
 // int_to_string(x : int) string
 // int_add(x : int, y : int) int
 // int_sub(x : int, y : int) int
+// int_mul(x : int, y : int) int
+// int_div(x : int, y : int) int
 // int_less(x : int, y : int) bool
 // print(s : string) struct{}
 // println(s : string) struct{}
@@ -39,6 +41,14 @@ func int_add(x int, y int) int {
 
 func int_sub(x int, y int) int {
     return x - y
+}
+
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
 }
 
 func int_less(x int, y int) bool {

--- a/crates/compiler/src/pprint/tast_pprint.rs
+++ b/crates/compiler/src/pprint/tast_pprint.rs
@@ -330,6 +330,19 @@ impl Expr {
                     .append(RcDoc::text("}"))
                     .group()
             }
+            Self::EBinary {
+                op,
+                lhs,
+                rhs,
+                ty: _,
+                resolution: _,
+            } => lhs
+                .to_doc(env)
+                .append(RcDoc::space())
+                .append(RcDoc::text(op.symbol()))
+                .append(RcDoc::space())
+                .append(rhs.to_doc(env))
+                .group(),
 
             Self::ECall { func, args, ty: _ } => {
                 let args_doc =

--- a/crates/compiler/src/pprint/tast_pprint.rs
+++ b/crates/compiler/src/pprint/tast_pprint.rs
@@ -343,6 +343,12 @@ impl Expr {
                 .append(RcDoc::space())
                 .append(rhs.to_doc(env))
                 .group(),
+            Self::EUnary {
+                op,
+                expr,
+                ty: _,
+                resolution: _,
+            } => RcDoc::text(op.symbol()).append(expr.to_doc(env)).group(),
 
             Self::ECall { func, args, ty: _ } => {
                 let args_doc =

--- a/crates/compiler/src/query.rs
+++ b/crates/compiler/src/query.rs
@@ -144,6 +144,7 @@ fn find_type_expr(env: &Env, tast: &tast::Expr, range: &rowan::TextRange) -> Opt
             }
             None
         }
+        tast::Expr::EUnary { expr, ty: _, .. } => find_type_expr(env, expr, range),
         tast::Expr::EProj {
             tuple,
             index: _,

--- a/crates/compiler/src/query.rs
+++ b/crates/compiler/src/query.rs
@@ -133,6 +133,17 @@ fn find_type_expr(env: &Env, tast: &tast::Expr, range: &rowan::TextRange) -> Opt
             }
             None
         }
+        tast::Expr::EBinary {
+            lhs, rhs, ty: _, ..
+        } => {
+            if let Some(expr) = find_type_expr(env, lhs, range) {
+                return Some(expr);
+            }
+            if let Some(expr) = find_type_expr(env, rhs, range) {
+                return Some(expr);
+            }
+            None
+        }
         tast::Expr::EProj {
             tuple,
             index: _,

--- a/crates/compiler/src/rename.rs
+++ b/crates/compiler/src/rename.rs
@@ -162,6 +162,15 @@ impl Rename {
                     args: new_args,
                 }
             }
+            ast::Expr::EBinary { op, lhs, rhs } => ast::Expr::EBinary {
+                op: *op,
+                lhs: Box::new(self.rename_expr(lhs, env)),
+                rhs: Box::new(self.rename_expr(rhs, env)),
+            },
+            ast::Expr::EProj { tuple, index } => ast::Expr::EProj {
+                tuple: Box::new(self.rename_expr(tuple, env)),
+                index: *index,
+            },
         }
     }
 

--- a/crates/compiler/src/rename.rs
+++ b/crates/compiler/src/rename.rs
@@ -162,6 +162,10 @@ impl Rename {
                     args: new_args,
                 }
             }
+            ast::Expr::EUnary { op, expr } => ast::Expr::EUnary {
+                op: *op,
+                expr: Box::new(self.rename_expr(expr, env)),
+            },
             ast::Expr::EBinary { op, lhs, rhs } => ast::Expr::EBinary {
                 op: *op,
                 lhs: Box::new(self.rename_expr(lhs, env)),

--- a/crates/compiler/src/tast.rs
+++ b/crates/compiler/src/tast.rs
@@ -1,4 +1,4 @@
-use ast::ast::{BinaryOp, Uident};
+use ast::ast::{BinaryOp, Uident, UnaryOp};
 use ena::unify::{EqUnifyValue, UnifyKey};
 use parser::syntax::MySyntaxNodePtr;
 
@@ -142,6 +142,12 @@ pub enum BinaryResolution {
     Overloaded { trait_name: Uident },
 }
 
+#[derive(Debug, Clone)]
+pub enum UnaryResolution {
+    Builtin,
+    Overloaded { trait_name: Uident },
+}
+
 impl UnifyKey for TypeVar {
     type Value = Option<Ty>;
 
@@ -205,6 +211,12 @@ pub enum Expr {
         args: Vec<Expr>,
         ty: Ty,
     },
+    EUnary {
+        op: UnaryOp,
+        expr: Box<Expr>,
+        ty: Ty,
+        resolution: UnaryResolution,
+    },
     EProj {
         tuple: Box<Expr>,
         index: usize,
@@ -232,6 +244,7 @@ impl Expr {
             Self::ELet { ty, .. } => ty.clone(),
             Self::EMatch { ty, .. } => ty.clone(),
             Self::ECall { ty, .. } => ty.clone(),
+            Self::EUnary { ty, .. } => ty.clone(),
             Self::EProj { ty, .. } => ty.clone(),
             Self::EBinary { ty, .. } => ty.clone(),
         }

--- a/crates/compiler/src/tast.rs
+++ b/crates/compiler/src/tast.rs
@@ -1,4 +1,4 @@
-use ast::ast::Uident;
+use ast::ast::{BinaryOp, Uident};
 use ena::unify::{EqUnifyValue, UnifyKey};
 use parser::syntax::MySyntaxNodePtr;
 
@@ -136,6 +136,12 @@ impl EqUnifyValue for Ty {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TypeVar(u32);
 
+#[derive(Debug, Clone)]
+pub enum BinaryResolution {
+    Builtin,
+    Overloaded { trait_name: Uident },
+}
+
 impl UnifyKey for TypeVar {
     type Value = Option<Ty>;
 
@@ -204,6 +210,13 @@ pub enum Expr {
         index: usize,
         ty: Ty,
     },
+    EBinary {
+        op: BinaryOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+        ty: Ty,
+        resolution: BinaryResolution,
+    },
 }
 
 impl Expr {
@@ -220,6 +233,7 @@ impl Expr {
             Self::EMatch { ty, .. } => ty.clone(),
             Self::ECall { ty, .. } => ty.clone(),
             Self::EProj { ty, .. } => ty.clone(),
+            Self::EBinary { ty, .. } => ty.clone(),
         }
     }
 }

--- a/crates/compiler/src/tests/cases/001.src.gom
+++ b/crates/compiler/src/tests/cases/001.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/001.src.gom
+++ b/crates/compiler/src/tests/cases/001.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/002.src.gom
+++ b/crates/compiler/src/tests/cases/002.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/002.src.gom
+++ b/crates/compiler/src/tests/cases/002.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/003.src.gom
+++ b/crates/compiler/src/tests/cases/003.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/003.src.gom
+++ b/crates/compiler/src/tests/cases/003.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/004.src.gom
+++ b/crates/compiler/src/tests/cases/004.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/004.src.gom
+++ b/crates/compiler/src/tests/cases/004.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/005.src.gom
+++ b/crates/compiler/src/tests/cases/005.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/005.src.gom
+++ b/crates/compiler/src/tests/cases/005.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/006.src.gom
+++ b/crates/compiler/src/tests/cases/006.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/006.src.gom
+++ b/crates/compiler/src/tests/cases/006.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/007.src.gom
+++ b/crates/compiler/src/tests/cases/007.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/007.src.gom
+++ b/crates/compiler/src/tests/cases/007.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/008.src.gom
+++ b/crates/compiler/src/tests/cases/008.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/008.src.gom
+++ b/crates/compiler/src/tests/cases/008.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/009.src.gom
+++ b/crates/compiler/src/tests/cases/009.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/009.src.gom
+++ b/crates/compiler/src/tests/cases/009.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/010.src.gom
+++ b/crates/compiler/src/tests/cases/010.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/010.src.gom
+++ b/crates/compiler/src/tests/cases/010.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/011.src.gom
+++ b/crates/compiler/src/tests/cases/011.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/011.src.gom
+++ b/crates/compiler/src/tests/cases/011.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/012.src.gom
+++ b/crates/compiler/src/tests/cases/012.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/012.src.gom
+++ b/crates/compiler/src/tests/cases/012.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/013.src.gom
+++ b/crates/compiler/src/tests/cases/013.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/013.src.gom
+++ b/crates/compiler/src/tests/cases/013.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/014.src.gom
+++ b/crates/compiler/src/tests/cases/014.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/014.src.gom
+++ b/crates/compiler/src/tests/cases/014.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/015.src.gom
+++ b/crates/compiler/src/tests/cases/015.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/015.src.gom
+++ b/crates/compiler/src/tests/cases/015.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/016.src.gom
+++ b/crates/compiler/src/tests/cases/016.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/016.src.gom
+++ b/crates/compiler/src/tests/cases/016.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/017.src.gom
+++ b/crates/compiler/src/tests/cases/017.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/017.src.gom
+++ b/crates/compiler/src/tests/cases/017.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/018.src.gom
+++ b/crates/compiler/src/tests/cases/018.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/018.src.gom
+++ b/crates/compiler/src/tests/cases/018.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/019.src.gom
+++ b/crates/compiler/src/tests/cases/019.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/019.src.gom
+++ b/crates/compiler/src/tests/cases/019.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/020.src.gom
+++ b/crates/compiler/src/tests/cases/020.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/020.src.gom
+++ b/crates/compiler/src/tests/cases/020.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/021.src.gom
+++ b/crates/compiler/src/tests/cases/021.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/021.src.gom
+++ b/crates/compiler/src/tests/cases/021.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/022.src.gom
+++ b/crates/compiler/src/tests/cases/022.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/022.src.gom
+++ b/crates/compiler/src/tests/cases/022.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/023.src.gom
+++ b/crates/compiler/src/tests/cases/023.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/023.src.gom
+++ b/crates/compiler/src/tests/cases/023.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/024.src.gom
+++ b/crates/compiler/src/tests/cases/024.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/024.src.gom
+++ b/crates/compiler/src/tests/cases/024.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/025_missing_match.src.gom
+++ b/crates/compiler/src/tests/cases/025_missing_match.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/cases/025_missing_match.src.gom
+++ b/crates/compiler/src/tests/cases/025_missing_match.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/cases/025_missing_match.src.out
+++ b/crates/compiler/src/tests/cases/025_missing_match.src.out
@@ -3,9 +3,9 @@ panic:
 
 goroutine 1 [running]:
 main.missing(...)
-	${WORKDIR}/main.go:51
+	${WORKDIR}/main.go:59
 main.main0(...)
-	${WORKDIR}/main.go:78
+	${WORKDIR}/main.go:86
 main.main()
-	${WORKDIR}/main.go:84 +0x65
+	${WORKDIR}/main.go:92 +0x65
 exit status 2

--- a/crates/compiler/src/tests/cases/025_missing_match.src.out
+++ b/crates/compiler/src/tests/cases/025_missing_match.src.out
@@ -3,9 +3,9 @@ panic:
 
 goroutine 1 [running]:
 main.missing(...)
-	${WORKDIR}/main.go:59
+	${WORKDIR}/main.go:63
 main.main0(...)
-	${WORKDIR}/main.go:86
+	${WORKDIR}/main.go:90
 main.main()
-	${WORKDIR}/main.go:92 +0x65
+	${WORKDIR}/main.go:96 +0x65
 exit status 2

--- a/crates/compiler/src/tests/examples/001_pattern_matching.src.gom
+++ b/crates/compiler/src/tests/examples/001_pattern_matching.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/examples/001_pattern_matching.src.gom
+++ b/crates/compiler/src/tests/examples/001_pattern_matching.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/examples/002_overloading.src.gom
+++ b/crates/compiler/src/tests/examples/002_overloading.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/examples/002_overloading.src.gom
+++ b/crates/compiler/src/tests/examples/002_overloading.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/compiler/src/tests/examples/003_fib.src.gom
+++ b/crates/compiler/src/tests/examples/003_fib.src.gom
@@ -28,6 +28,14 @@ func int_sub(x int, y int) int {
     return x - y
 }
 
+func int_mul(x int, y int) int {
+    return x * y
+}
+
+func int_div(x int, y int) int {
+    return x / y
+}
+
 func int_less(x int, y int) bool {
     return x < y
 }

--- a/crates/compiler/src/tests/examples/003_fib.src.gom
+++ b/crates/compiler/src/tests/examples/003_fib.src.gom
@@ -20,6 +20,10 @@ func int_to_string(x int) string {
     return fmt.Sprintf("%d", x)
 }
 
+func int_neg(x int) int {
+    return -x
+}
+
 func int_add(x int, y int) int {
     return x + y
 }

--- a/crates/cst/src/nodes.rs
+++ b/crates/cst/src/nodes.rs
@@ -833,7 +833,22 @@ impl BinaryExpr {
     }
 
     pub fn op(&self) -> Option<MySyntaxToken> {
-        support::token(&self.syntax, MySyntaxKind::Dot)
+        self.syntax.children_with_tokens().find_map(|element| {
+            element.into_token().and_then(|token| {
+                if matches!(
+                    token.kind(),
+                    MySyntaxKind::Plus
+                        | MySyntaxKind::Minus
+                        | MySyntaxKind::Star
+                        | MySyntaxKind::Slash
+                        | MySyntaxKind::Dot
+                ) {
+                    Some(token)
+                } else {
+                    None
+                }
+            })
+        })
     }
 }
 

--- a/crates/cst/src/nodes.rs
+++ b/crates/cst/src/nodes.rs
@@ -452,6 +452,7 @@ pub enum Expr {
     TupleExpr(TupleExpr),
     LetExpr(LetExpr),
     BinaryExpr(BinaryExpr),
+    PrefixExpr(PrefixExpr),
 }
 
 impl CstNode for Expr {
@@ -486,6 +487,7 @@ impl CstNode for Expr {
             EXPR_TUPLE => Expr::TupleExpr(TupleExpr { syntax }),
             EXPR_LET => Expr::LetExpr(LetExpr { syntax }),
             EXPR_BINARY => Expr::BinaryExpr(BinaryExpr { syntax }),
+            EXPR_PREFIX => Expr::PrefixExpr(PrefixExpr { syntax }),
             _ => return None,
         };
         Some(res)
@@ -504,6 +506,7 @@ impl CstNode for Expr {
             Self::TupleExpr(it) => &it.syntax,
             Self::LetExpr(it) => &it.syntax,
             Self::BinaryExpr(it) => &it.syntax,
+            Self::PrefixExpr(it) => &it.syntax,
         }
     }
 }
@@ -854,6 +857,33 @@ impl BinaryExpr {
 
 impl_cst_node_simple!(BinaryExpr, MySyntaxKind::EXPR_BINARY);
 impl_display_via_syntax!(BinaryExpr);
+
+////////////////////////////////////////////////////////////////////////////////
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PrefixExpr {
+    pub(crate) syntax: MySyntaxNode,
+}
+
+impl PrefixExpr {
+    pub fn expr(&self) -> Option<Expr> {
+        support::child(&self.syntax)
+    }
+
+    pub fn op(&self) -> Option<MySyntaxToken> {
+        self.syntax.children_with_tokens().find_map(|element| {
+            element.into_token().and_then(|token| {
+                if matches!(token.kind(), MySyntaxKind::Minus) {
+                    Some(token)
+                } else {
+                    None
+                }
+            })
+        })
+    }
+}
+
+impl_cst_node_simple!(PrefixExpr, MySyntaxKind::EXPR_PREFIX);
+impl_display_via_syntax!(PrefixExpr);
 
 ////////////////////////////////////////////////////////////////////////////////
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -150,10 +150,6 @@ fn struct_literal_field(p: &mut Parser) {
     p.close(m, MySyntaxKind::STRUCT_LITERAL_FIELD);
 }
 
-fn prefix_binding_power(_op: TokenKind) -> Option<((), u8)> {
-    None
-}
-
 fn postfix_binding_power(op: TokenKind) -> Option<(u8, ())> {
     match op {
         T!['('] => Some((7, ())),
@@ -211,21 +207,10 @@ fn let_expr(p: &mut Parser) {
 }
 
 fn expr_bp(p: &mut Parser, min_bp: u8) {
-    let op = p.peek();
-
-    let lhs = if let Some(((), r_bp)) = prefix_binding_power(op) {
-        let _m = p.open();
-        p.advance();
-        expr_bp(p, r_bp);
-        todo!()
-    } else {
-        atom(p)
+    let mut lhs = match atom(p) {
+        Some(lhs) => lhs,
+        None => return,
     };
-
-    if lhs.is_none() {
-        return;
-    }
-    let mut lhs = lhs.unwrap();
 
     loop {
         if p.eof() {
@@ -254,13 +239,9 @@ fn expr_bp(p: &mut Parser, min_bp: u8) {
                 break;
             }
             let m = lhs.precede(p);
-            if op == T![:] {
-                todo!()
-            } else {
-                p.advance();
-                expr_bp(p, r_bp);
-                lhs = m.completed(p, MySyntaxKind::EXPR_BINARY);
-            }
+            p.advance();
+            expr_bp(p, r_bp);
+            lhs = m.completed(p, MySyntaxKind::EXPR_BINARY);
             continue;
         }
         break;

--- a/crates/parser/src/syntax.rs
+++ b/crates/parser/src/syntax.rs
@@ -73,6 +73,7 @@ pub enum MySyntaxKind {
     EXPR_LIDENT,
     EXPR_PAREN,
     EXPR_BINARY,
+    EXPR_PREFIX,
     EXPR_IF,
     EXPR_LET,
     EXPR_LET_VALUE,


### PR DESCRIPTION
## Summary
- add binary operator and projection expressions to the AST and typed AST, plus pretty-printers
- teach the Pratt parser and CST to surface infix operator nodes with their tokens
- lower, type-check, and compile binary expressions, including builtin Go runtime helpers

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dd5c59ffa0832b8413172265f39005