### PR TITLE
feat: add lowering diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,11 @@ name = "ast"
 version = "0.0.0"
 dependencies = [
  "cst",
+ "diagnostics",
  "expect-test",
  "parser",
  "pretty",
+ "text-size",
 ]
 
 [[package]]
@@ -502,6 +504,7 @@ dependencies = [
  "ast",
  "compiler",
  "cst",
+ "diagnostics",
  "im",
  "parser",
  "wasm-bindgen",

--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -7,6 +7,8 @@ edition.workspace = true
 pretty.workspace = true
 cst.workspace = true
 parser.workspace = true
+diagnostics.workspace = true
+text-size.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/crates/compiler/src/main.rs
+++ b/crates/compiler/src/main.rs
@@ -25,6 +25,15 @@ fn main() {
                         eprintln!("error: {}: {}", file_path.display(), error);
                     }
                 }
+                CompilationError::Lower { diagnostics } => {
+                    for diagnostic in diagnostics.iter() {
+                        eprintln!(
+                            "error (lower): {}: {}",
+                            file_path.display(),
+                            diagnostic.message()
+                        );
+                    }
+                }
                 CompilationError::Typer { diagnostics } => {
                     for error in format_typer_diagnostics(diagnostics) {
                         eprintln!("error (typer): {}: {}", file_path.display(), error);

--- a/crates/compiler/src/query.rs
+++ b/crates/compiler/src/query.rs
@@ -36,7 +36,11 @@ pub fn hover_type(src: &str, line: u32, col: u32) -> Option<String> {
         }
     }?;
 
-    let ast = ast::lower::lower(cst).unwrap_or_else(|| panic!("failed to lower CST to AST"));
+    let lower = ast::lower::lower(cst);
+    let ast = match lower.into_result() {
+        Ok(ast) => ast,
+        Err(_) => return None,
+    };
     let (tast, env) = crate::typer::check_file(ast);
 
     let ty = find_type(&env, &tast, &range);

--- a/crates/compiler/src/tests/struct_type_test.rs
+++ b/crates/compiler/src/tests/struct_type_test.rs
@@ -14,7 +14,9 @@ fn typecheck(src: &str) -> (tast::File, Env) {
     }
     let root = MySyntaxNode::new_root(parsed.green_node);
     let cst = cst::cst::File::cast(root).expect("failed to cast syntax tree");
-    let ast = ast::lower::lower(cst).expect("failed to lower to AST");
+    let ast = ast::lower::lower(cst)
+        .into_result()
+        .expect("failed to lower to AST");
     crate::typer::check_file(ast)
 }
 

--- a/crates/compiler/src/tests/trait_impl_test.rs
+++ b/crates/compiler/src/tests/trait_impl_test.rs
@@ -16,7 +16,9 @@ fn typecheck(src: &str) -> (tast::File, Env) {
     }
     let root = MySyntaxNode::new_root(parsed.green_node);
     let cst = cst::cst::File::cast(root).expect("failed to cast syntax tree");
-    let ast = ast::lower::lower(cst).expect("failed to lower to AST");
+    let ast = ast::lower::lower(cst)
+        .into_result()
+        .expect("failed to lower to AST");
     crate::typer::check_file(ast)
 }
 

--- a/crates/wasm-app/Cargo.toml
+++ b/crates/wasm-app/Cargo.toml
@@ -13,6 +13,7 @@ ast.workspace = true
 compiler.workspace = true
 im.workspace = true
 wasm-bindgen = { version = "0.2.100" }
+diagnostics.workspace = true
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O", "--enable-bulk-memory"]

--- a/crates/wasm-app/src/lib.rs
+++ b/crates/wasm-app/src/lib.rs
@@ -1,4 +1,5 @@
 use cst::cst::CstNode;
+use diagnostics::Diagnostics;
 use parser::{parser::ParseResult, syntax::MySyntaxNode};
 
 use compiler::env::format_typer_diagnostics;
@@ -12,7 +13,11 @@ pub fn execute(src: &str) -> String {
     }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
-    let ast = ast::lower::lower(cst).unwrap();
+    let lower = ast::lower::lower(cst);
+    let ast = match lower.into_result() {
+        Ok(ast) => ast,
+        Err(diagnostics) => return format_lower_errors(diagnostics),
+    };
 
     let (tast, env) = compiler::typer::check_file(ast);
     let typer_errors = format_typer_diagnostics(&env.diagnostics);
@@ -36,7 +41,11 @@ pub fn compile_to_core(src: &str) -> String {
     }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
-    let ast = ast::lower::lower(cst).unwrap();
+    let lower = ast::lower::lower(cst);
+    let ast = match lower.into_result() {
+        Ok(ast) => ast,
+        Err(diagnostics) => return format_lower_errors(diagnostics),
+    };
 
     let (tast, env) = compiler::typer::check_file(ast);
     let typer_errors = format_typer_diagnostics(&env.diagnostics);
@@ -60,7 +69,11 @@ pub fn compile_to_mono(src: &str) -> String {
     }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
-    let ast = ast::lower::lower(cst).unwrap();
+    let lower = ast::lower::lower(cst);
+    let ast = match lower.into_result() {
+        Ok(ast) => ast,
+        Err(diagnostics) => return format_lower_errors(diagnostics),
+    };
 
     let (tast, mut env) = compiler::typer::check_file(ast);
     let typer_errors = format_typer_diagnostics(&env.diagnostics);
@@ -85,7 +98,11 @@ pub fn compile_to_anf(src: &str) -> String {
     }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
-    let ast = ast::lower::lower(cst).unwrap();
+    let lower = ast::lower::lower(cst);
+    let ast = match lower.into_result() {
+        Ok(ast) => ast,
+        Err(diagnostics) => return format_lower_errors(diagnostics),
+    };
 
     let (tast, mut env) = compiler::typer::check_file(ast);
     let typer_errors = format_typer_diagnostics(&env.diagnostics);
@@ -112,7 +129,11 @@ pub fn compile_to_go(src: &str) -> String {
     }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
-    let ast = ast::lower::lower(cst).unwrap();
+    let lower = ast::lower::lower(cst);
+    let ast = match lower.into_result() {
+        Ok(ast) => ast,
+        Err(diagnostics) => return format_lower_errors(diagnostics),
+    };
 
     let (tast, mut env) = compiler::typer::check_file(ast);
     let typer_errors = format_typer_diagnostics(&env.diagnostics);
@@ -150,7 +171,11 @@ pub fn get_ast(src: &str) -> String {
     }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
-    let ast = ast::lower::lower(cst).unwrap();
+    let lower = ast::lower::lower(cst);
+    let ast = match lower.into_result() {
+        Ok(ast) => ast,
+        Err(diagnostics) => return format_lower_errors(diagnostics),
+    };
     format!("{:#?}", ast)
 }
 
@@ -162,7 +187,11 @@ pub fn get_tast(src: &str) -> String {
     }
     let root = MySyntaxNode::new_root(result.green_node);
     let cst = cst::cst::File::cast(root).unwrap();
-    let ast = ast::lower::lower(cst).unwrap();
+    let lower = ast::lower::lower(cst);
+    let ast = match lower.into_result() {
+        Ok(ast) => ast,
+        Err(diagnostics) => return format_lower_errors(diagnostics),
+    };
 
     let (tast, env) = compiler::typer::check_file(ast);
     let typer_errors = format_typer_diagnostics(&env.diagnostics);
@@ -186,6 +215,20 @@ fn format_parse_errors(result: &ParseResult, src: &str) -> String {
         .format_errors(src)
         .into_iter()
         .map(|err| format!("error: {}", err))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_lower_errors(diagnostics: Diagnostics) -> String {
+    diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            format!(
+                "error ({}): {}",
+                diagnostic.stage().as_str(),
+                diagnostic.message()
+            )
+        })
         .collect::<Vec<_>>()
         .join("\n")
 }


### PR DESCRIPTION
## Summary
- collect diagnostics during AST lowering instead of panicking
- surface lowering diagnostics through the CLI, wasm bindings, and tests

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68de4187c0e0832b94dfef4bb6af15ee