### PR TITLE
feat: unify trait impl type encoding

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -10,6 +10,7 @@ pub mod pprint;
 pub mod query;
 pub mod rename;
 pub mod tast;
+pub mod type_encoding;
 pub mod typer;
 
 #[cfg(test)]

--- a/crates/compiler/src/mangle.rs
+++ b/crates/compiler/src/mangle.rs
@@ -1,40 +1,7 @@
-use crate::tast;
+use crate::{tast, type_encoding::encode_ty};
 use ::ast::ast;
 
 pub fn mangle_impl_name(trait_name: &ast::Uident, for_ty: &tast::Ty, method_name: &str) -> String {
-    // Create a unique string representation of the type `for_ty`. Handle complex types carefully.
-    let for_ty_str = match for_ty {
-        tast::Ty::TUnit => "unit".to_string(),
-        tast::Ty::TBool => "bool".to_string(),
-        tast::Ty::TInt => "int".to_string(),
-        tast::Ty::TString => "string".to_string(),
-        tast::Ty::TTuple { typs } => {
-            let inner = typs
-                .iter()
-                .map(|ty| format!("{:?}", ty))
-                .collect::<Vec<_>>()
-                .join("_");
-            format!("Tuple_{}", inner)
-        }
-        tast::Ty::TCon { name } => format!("Con_{}", name),
-        tast::Ty::TApp { ty, args } => {
-            let base = ty.get_constr_name_unsafe();
-            let inner = args
-                .iter()
-                .map(|ty| format!("{:?}", ty))
-                .collect::<Vec<_>>()
-                .join("_");
-            format!("App_{}_{}", base, inner)
-        }
-        tast::Ty::TParam { .. } => {
-            unreachable!()
-        }
-        tast::Ty::TFunc { .. } => {
-            unreachable!()
-        }
-        tast::Ty::TVar(..) => {
-            unreachable!()
-        }
-    };
+    let for_ty_str = encode_ty(for_ty);
     format!("impl_{}_{}_{}", trait_name.0, for_ty_str, method_name)
 }

--- a/crates/compiler/src/mono.rs
+++ b/crates/compiler/src/mono.rs
@@ -1,6 +1,7 @@
 use super::core;
 use crate::env::{EnumDef, Env, StructDef};
 use crate::tast::{self, Constructor, Ty};
+use crate::type_encoding::encode_ty;
 use ast::ast::Uident;
 use indexmap::{IndexMap, IndexSet};
 use std::collections::VecDeque;
@@ -82,36 +83,6 @@ pub fn mono(env: &mut Env, file: core::File) -> core::File {
                 params: params.iter().map(|t| subst_ty(t, s)).collect(),
                 ret_ty: Box::new(subst_ty(ret_ty, s)),
             },
-        }
-    }
-
-    fn encode_ty(ty: &Ty) -> String {
-        match ty {
-            Ty::TUnit => "unit".to_string(),
-            Ty::TBool => "bool".to_string(),
-            Ty::TInt => "int".to_string(),
-            Ty::TString => "string".to_string(),
-            Ty::TVar(_v) => "Var".to_string(),
-            Ty::TParam { name } => format!("TParam_{}", name),
-            Ty::TTuple { typs } => {
-                let inner = typs.iter().map(encode_ty).collect::<Vec<_>>().join("_");
-                format!("Tuple_{}", inner)
-            }
-            Ty::TCon { name } => name.clone(),
-            Ty::TApp { ty, args } => {
-                let base = ty.get_constr_name_unsafe();
-                if args.is_empty() {
-                    base
-                } else {
-                    let inner = args.iter().map(encode_ty).collect::<Vec<_>>().join("_");
-                    format!("{}_{}", base, inner)
-                }
-            }
-            Ty::TFunc { params, ret_ty } => {
-                let p = params.iter().map(encode_ty).collect::<Vec<_>>().join("_");
-                let r = encode_ty(ret_ty);
-                format!("Fn_{}_to_{}", p, r)
-            }
         }
     }
 

--- a/crates/compiler/src/tests/cases/017.src.anf
+++ b/crates/compiler/src/tests/cases/017.src.anf
@@ -6,7 +6,7 @@ fn impl_ToString_bool_to_string(self/1: bool) -> string {
   bool_to_string(self/1)
 }
 
-fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (int, int)) -> string {
+fn impl_ToString_Tuple_int_int_to_string(self/2: (int, int)) -> string {
   "(?, ?)"
 }
 
@@ -18,7 +18,7 @@ fn main() -> unit {
   let t4 = impl_ToString_bool_to_string(x/4) in
   let mtmp1 = string_println(t4) in
   let x/5 = (3, 4) in
-  let t5 = impl_ToString_Tuple_TInt_TInt_to_string(x/5) in
+  let t5 = impl_ToString_Tuple_int_int_to_string(x/5) in
   let mtmp2 = string_println(t5) in
   ()
 }

--- a/crates/compiler/src/tests/cases/017.src.core
+++ b/crates/compiler/src/tests/cases/017.src.core
@@ -6,7 +6,7 @@ fn impl_ToString_bool_to_string(self/1: bool) -> string {
   bool_to_string(self/1)
 }
 
-fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (int, int)) -> string {
+fn impl_ToString_Tuple_int_int_to_string(self/2: (int, int)) -> string {
   "(?, ?)"
 }
 
@@ -16,6 +16,6 @@ fn main() -> unit {
   let x/4 = true in
   let mtmp1 = string_println(impl_ToString_bool_to_string(x/4)) in
   let x/5 = (3, 4) in
-  let mtmp2 = string_println(impl_ToString_Tuple_TInt_TInt_to_string(x/5)) in
+  let mtmp2 = string_println(impl_ToString_Tuple_int_int_to_string(x/5)) in
   ()
 }

--- a/crates/compiler/src/tests/cases/017.src.gom
+++ b/crates/compiler/src/tests/cases/017.src.gom
@@ -38,7 +38,7 @@ func impl_ToString_bool_to_string(self__1 bool) string {
     return ret7
 }
 
-func impl_ToString_Tuple_TInt_TInt_to_string(self__2 Tuple2_int_int) string {
+func impl_ToString_Tuple_int_int_to_string(self__2 Tuple2_int_int) string {
     var ret8 string
     ret8 = "(?, ?)"
     return ret8
@@ -56,7 +56,7 @@ func main0() struct{} {
         _0: 3,
         _1: 4,
     }
-    var t5 string = impl_ToString_Tuple_TInt_TInt_to_string(x__5)
+    var t5 string = impl_ToString_Tuple_int_int_to_string(x__5)
     string_println(t5)
     ret9 = struct{}{}
     return ret9

--- a/crates/compiler/src/tests/cases/017.src.mono
+++ b/crates/compiler/src/tests/cases/017.src.mono
@@ -6,7 +6,7 @@ fn impl_ToString_bool_to_string(self/1: bool) -> string {
   bool_to_string(self/1)
 }
 
-fn impl_ToString_Tuple_TInt_TInt_to_string(self/2: (int, int)) -> string {
+fn impl_ToString_Tuple_int_int_to_string(self/2: (int, int)) -> string {
   "(?, ?)"
 }
 
@@ -16,6 +16,6 @@ fn main() -> unit {
   let x/4 = true in
   let mtmp1 = string_println(impl_ToString_bool_to_string(x/4)) in
   let x/5 = (3, 4) in
-  let mtmp2 = string_println(impl_ToString_Tuple_TInt_TInt_to_string(x/5)) in
+  let mtmp2 = string_println(impl_ToString_Tuple_int_int_to_string(x/5)) in
   ()
 }

--- a/crates/compiler/src/tests/trait_impl_test.rs
+++ b/crates/compiler/src/tests/trait_impl_test.rs
@@ -129,3 +129,48 @@ impl Unknown for int {
 
     expect_single_error(src, "Trait Unknown is not defined");
 }
+
+#[test]
+fn impl_for_struct_reports_missing_method_diagnostic() {
+    let src = r#"
+struct Point { x: int, y: int }
+
+trait Display {
+    fn show(Self) -> string;
+    fn debug(Self) -> string;
+}
+
+impl Display for Point {
+    fn show(self: Point) -> string { "value" }
+}
+"#;
+
+    expect_single_error(
+        src,
+        "Trait Display implementation for TCon(Point) is missing method debug",
+    );
+}
+
+#[test]
+fn impl_for_generic_type_reports_missing_method_diagnostic() {
+    let src = r#"
+enum Option[T] {
+    Some(T),
+    None,
+}
+
+trait Display {
+    fn show(Self) -> string;
+    fn debug(Self) -> string;
+}
+
+impl Display for Option[int] {
+    fn show(self: Option[int]) -> string { "value" }
+}
+"#;
+
+    expect_single_error(
+        src,
+        "Trait Display implementation for TApp(TCon(Option), [TInt]) is missing method debug",
+    );
+}

--- a/crates/compiler/src/type_encoding.rs
+++ b/crates/compiler/src/type_encoding.rs
@@ -1,0 +1,162 @@
+use crate::tast;
+
+pub fn encode_ty(ty: &tast::Ty) -> String {
+    match ty {
+        tast::Ty::TUnit => "unit".to_string(),
+        tast::Ty::TBool => "bool".to_string(),
+        tast::Ty::TInt => "int".to_string(),
+        tast::Ty::TString => "string".to_string(),
+        tast::Ty::TVar(_v) => "Var".to_string(),
+        tast::Ty::TParam { name } => format!("TParam_{}", name),
+        tast::Ty::TTuple { typs } => {
+            let inner = typs.iter().map(encode_ty).collect::<Vec<_>>().join("_");
+            format!("Tuple_{}", inner)
+        }
+        tast::Ty::TCon { name } => name.clone(),
+        tast::Ty::TApp { ty, args } => {
+            let base = ty.get_constr_name_unsafe();
+            if args.is_empty() {
+                base
+            } else {
+                let inner = args.iter().map(encode_ty).collect::<Vec<_>>().join("_");
+                format!("{}_{}", base, inner)
+            }
+        }
+        tast::Ty::TFunc { params, ret_ty } => {
+            let p = params.iter().map(encode_ty).collect::<Vec<_>>().join("_");
+            let r = encode_ty(ret_ty);
+            format!("Fn_{}_to_{}", p, r)
+        }
+    }
+}
+
+pub fn decode_ty(encoded: &str) -> Result<tast::Ty, String> {
+    if encoded.is_empty() {
+        return Err("empty type encoding".to_string());
+    }
+    let tokens: Vec<&str> = encoded.split('_').collect();
+    decode_range(&tokens, 0, tokens.len())
+}
+
+fn decode_range(tokens: &[&str], start: usize, end: usize) -> Result<tast::Ty, String> {
+    if start >= end {
+        return Err("invalid type encoding range".to_string());
+    }
+    let head = tokens[start];
+    match head {
+        "unit" => {
+            if start + 1 == end {
+                Ok(tast::Ty::TUnit)
+            } else {
+                Err("unexpected trailing tokens after unit".to_string())
+            }
+        }
+        "bool" => {
+            if start + 1 == end {
+                Ok(tast::Ty::TBool)
+            } else {
+                Err("unexpected trailing tokens after bool".to_string())
+            }
+        }
+        "int" => {
+            if start + 1 == end {
+                Ok(tast::Ty::TInt)
+            } else {
+                Err("unexpected trailing tokens after int".to_string())
+            }
+        }
+        "string" => {
+            if start + 1 == end {
+                Ok(tast::Ty::TString)
+            } else {
+                Err("unexpected trailing tokens after string".to_string())
+            }
+        }
+        "Var" => Err("type variables cannot be decoded".to_string()),
+        "TParam" => {
+            if start + 2 == end {
+                Ok(tast::Ty::TParam {
+                    name: tokens[start + 1].to_string(),
+                })
+            } else {
+                Err("malformed type parameter encoding".to_string())
+            }
+        }
+        "Tuple" => {
+            let elems = decode_list(tokens, start + 1, end)?;
+            if elems.is_empty() {
+                Err("tuple encoding must have at least one element".to_string())
+            } else {
+                Ok(tast::Ty::TTuple { typs: elems })
+            }
+        }
+        "Fn" => {
+            let mut to_pos = None;
+            for idx in start + 1..end {
+                if tokens[idx] == "to" {
+                    to_pos = Some(idx);
+                    break;
+                }
+            }
+            let to_pos =
+                to_pos.ok_or_else(|| "function encoding missing to delimiter".to_string())?;
+            let params = decode_params(tokens, start + 1, to_pos)?;
+            let ret = decode_range(tokens, to_pos + 1, end)?;
+            Ok(tast::Ty::TFunc {
+                params,
+                ret_ty: Box::new(ret),
+            })
+        }
+        _ => {
+            if start + 1 == end {
+                Ok(tast::Ty::TCon {
+                    name: head.to_string(),
+                })
+            } else {
+                let args = decode_list(tokens, start + 1, end)?;
+                Ok(tast::Ty::TApp {
+                    ty: Box::new(tast::Ty::TCon {
+                        name: head.to_string(),
+                    }),
+                    args,
+                })
+            }
+        }
+    }
+}
+
+fn decode_params(tokens: &[&str], start: usize, end: usize) -> Result<Vec<tast::Ty>, String> {
+    if start >= end {
+        return Ok(vec![]);
+    }
+    if start + 1 == end && tokens[start].is_empty() {
+        return Ok(vec![]);
+    }
+    decode_list(tokens, start, end)
+}
+
+fn decode_list(tokens: &[&str], start: usize, end: usize) -> Result<Vec<tast::Ty>, String> {
+    if start >= end {
+        return Ok(vec![]);
+    }
+    let mut items = Vec::new();
+    let mut cur = start;
+    while cur < end {
+        if tokens[cur].is_empty() {
+            return Err("unexpected empty token in type encoding".to_string());
+        }
+        let (ty, next) = decode_next(tokens, cur, end)?;
+        items.push(ty);
+        cur = next;
+    }
+    Ok(items)
+}
+
+fn decode_next(tokens: &[&str], start: usize, end: usize) -> Result<(tast::Ty, usize), String> {
+    for mid in (start + 1..=end).rev() {
+        if let Ok(ty) = decode_range(tokens, start, mid) {
+            return Ok((ty, mid));
+        }
+    }
+    Err("failed to decode type component".to_string())
+}

--- a/crates/compiler/src/typer.rs
+++ b/crates/compiler/src/typer.rs
@@ -8,6 +8,7 @@ use crate::{
     env::{self, Constraint, Env},
     rename,
     tast::{self, TypeVar},
+    type_encoding::encode_ty,
 };
 
 fn binary_supports_builtin(op: ast::BinaryOp, lhs: &tast::Ty, rhs: &tast::Ty) -> bool {
@@ -446,7 +447,7 @@ fn collect_typedefs(env: &mut Env, ast: &ast::File) {
 
                     if method_ok {
                         env.trait_impls.insert(
-                            (trait_name_str.clone(), for_ty.clone(), method_name),
+                            (trait_name_str.clone(), encode_ty(&for_ty), method_name),
                             impl_method_ty,
                         );
                     }

--- a/crates/compiler/tests/trait_impl_pipeline.rs
+++ b/crates/compiler/tests/trait_impl_pipeline.rs
@@ -1,0 +1,54 @@
+use std::path::Path;
+
+use compiler::pipeline;
+
+#[test]
+fn pipeline_generates_trait_impl_functions_for_struct_and_generic_types() {
+    let src = r#"
+struct Point { x: int, y: int }
+
+enum Option[T] {
+    Some(T),
+    None,
+}
+
+trait Display {
+    fn show(Self) -> string;
+}
+
+impl Display for Point {
+    fn show(self: Point) -> string { "Point" }
+}
+
+impl Display for Option[int] {
+    fn show(self: Option[int]) -> string { "Option" }
+}
+"#;
+
+    let compilation = pipeline::compile(Path::new("inline.src"), src)
+        .expect("pipeline compilation should succeed");
+
+    let keys: Vec<(String, String, String)> = compilation
+        .env
+        .trait_impls
+        .keys()
+        .map(|(trait_name, ty_enc, method)| (trait_name.clone(), ty_enc.clone(), method.0.clone()))
+        .collect();
+
+    assert!(
+        keys.contains(&(
+            "Display".to_string(),
+            "Point".to_string(),
+            "show".to_string()
+        )),
+        "expected struct impl registration in environment"
+    );
+    assert!(
+        keys.contains(&(
+            "Display".to_string(),
+            "Option_int".to_string(),
+            "show".to_string(),
+        )),
+        "expected generic impl registration in environment"
+    );
+}


### PR DESCRIPTION
## Summary
- add a shared type encoding/decoding helper and reuse it for trait impl mangling and monomorphization
- switch trait impl registration to use encoded type keys and expand diagnostics/tests for struct and generic impls
- add a pipeline integration test and update expect snapshots for the new naming scheme

## Testing
- cargo fmt
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dfbcede704832b95b88be996496b75