### PR TITLE
feat: show generics in AST custom type printouts

### DIFF
--- a/crates/ast/src/ast_pprint.rs
+++ b/crates/ast/src/ast_pprint.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     Arm, EnumDef, Expr, File, Fn, ImplBlock, Item, Pat, StructDef, TraitDef, TraitMethodSignature,
-    Ty,
+    Ty, Uident,
 };
 use pretty::RcDoc;
 
@@ -332,11 +332,25 @@ impl Arm {
     }
 }
 
+fn generics_to_doc(generics: &[Uident]) -> RcDoc<'_, ()> {
+    if generics.is_empty() {
+        RcDoc::nil()
+    } else {
+        RcDoc::text("[")
+            .append(RcDoc::intersperse(
+                generics.iter().map(|g| RcDoc::text(g.0.clone())),
+                RcDoc::text(", "),
+            ))
+            .append(RcDoc::text("]"))
+    }
+}
+
 impl EnumDef {
     pub fn to_doc(&self) -> RcDoc<'_, ()> {
         let header = RcDoc::text("enum")
             .append(RcDoc::space())
-            .append(RcDoc::text(&self.name.0));
+            .append(RcDoc::text(&self.name.0))
+            .append(generics_to_doc(&self.generics));
 
         let variants_doc =
             RcDoc::concat(self.variants.iter().enumerate().map(|(i, (name, types))| {
@@ -380,7 +394,8 @@ impl StructDef {
     pub fn to_doc(&self) -> RcDoc<'_, ()> {
         let header = RcDoc::text("struct")
             .append(RcDoc::space())
-            .append(RcDoc::text(&self.name.0));
+            .append(RcDoc::text(&self.name.0))
+            .append(generics_to_doc(&self.generics));
 
         let fields_doc = RcDoc::concat(self.fields.iter().map(|(name, ty)| {
             RcDoc::hardline()

--- a/crates/compiler/src/tests/cases/016.src.ast
+++ b/crates/compiler/src/tests/cases/016.src.ast
@@ -1,4 +1,4 @@
-enum List {
+enum List[T] {
     Nil,
     Cons(T, List[T])
 }

--- a/crates/compiler/src/tests/cases/019.src.ast
+++ b/crates/compiler/src/tests/cases/019.src.ast
@@ -3,7 +3,7 @@ struct Point {
     y: int,
 }
 
-struct Wrapper {
+struct Wrapper[T] {
     value: T,
 }
 

--- a/crates/compiler/src/tests/cases/020.src.ast
+++ b/crates/compiler/src/tests/cases/020.src.ast
@@ -3,11 +3,11 @@ struct Point {
     y: int,
 }
 
-struct Wrapper {
+struct Wrapper[T] {
     value: T,
 }
 
-enum Shape {
+enum Shape[T] {
     Dot(Point),
     Wrapped(Wrapper[T]),
     Origin

--- a/crates/compiler/src/tests/cases/029_trait_impl.src.ast
+++ b/crates/compiler/src/tests/cases/029_trait_impl.src.ast
@@ -3,7 +3,7 @@ struct Point {
     y: int,
 }
 
-enum Option {
+enum Option[T] {
     Some(T),
     None
 }


### PR DESCRIPTION
## Summary
- render generic parameter lists when pretty-printing struct and enum definitions in the AST view
- refresh AST golden snapshots so generic custom types appear with their type parameters

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e2e203b224832b94493f8468dbb83e